### PR TITLE
Remove wily from precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
     rev: v1.0.6
     hooks:
     - id: python-bandit-vulnerability-check
+      stages: [pre-push]
 -   repo: local
     hooks:
     - id: pytest


### PR DESCRIPTION
Remove the pre-commit checks performed by wily (for code complexity analysis), as we decided these are too heavy to run before every commit.

Also bump up the versions of the pre-commit check dependencies (performed automatically via `poetry run pre-commit autoupdate`).