### PR TITLE
Fix non-portability of the ID extraction from URIs. It was using the …

### DIFF
--- a/src/overseers/overseer.py
+++ b/src/overseers/overseer.py
@@ -74,7 +74,8 @@ class Overseer(metaclass=Singleton):
         Returns:
             The integer id that maps to the URI
         """
-        return int(urlparse(uri).path.rstrip(os.sep).split(os.sep).pop())
+        uri_sep: str = "/"
+        return int(urlparse(uri).path.rstrip(uri_sep).split(uri_sep).pop())
 
     def _get_object_from_mytardis(
         self,

--- a/tests/test_overseers.py
+++ b/tests/test_overseers.py
@@ -31,6 +31,9 @@ def fixture_overseer_plain(
 
 
 def test_staticmethod_resource_uri_to_id() -> None:
+    test_uri = URI("/v1/user/10")
+    assert Overseer.resource_uri_to_id(test_uri) == 10
+
     test_uri = URI("/v1/user/10/")
     assert Overseer.resource_uri_to_id(test_uri) == 10
 


### PR DESCRIPTION
Fix non-portability of the ID extraction from URIs. It was using the filesystem separator, which on Windows is different from the URI separator, so a test was failing on Windows.