### PR TITLE
Delete a file which seems to be a WSL artifact and causes an error in Git on Windows.

### DIFF
--- a/src/beneficiations/beneficiation_consts.py:Zone.Identifier
+++ b/src/beneficiations/beneficiation_consts.py:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://github.com/


### PR DESCRIPTION
The file `beneficiation_consts.py:Zone.Identifier` seems to be an artifact associated with WSL (it's used in NTFS file systems to indicate file origin, apparently). The presence of this file seems to cause Git to error out in Windows-proper when pulling, and it doesn't seem to be needed, so this PR deletes it.