### PR TITLE
Bump up the version of the setup-python action from v1 to v4.

### DIFF
--- a/.github/workflows/mytardis_ingestion.yml
+++ b/.github/workflows/mytardis_ingestion.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -28,7 +28,7 @@ jobs:
 
     - name: Run pytest
       run: PYTHONPATH=src/ poetry run python -m pytest -v --cov=src/ tests/
-      
+
     - name: Run Coverage
       run: PYTHONPATH=src/ poetry run python -m coverage report -m;
 


### PR DESCRIPTION
v1 relies on Node 12, which Github is deprecating support for.

More info available here:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/