### PR TITLE
Roll back the version of PyLint used in the pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
     -   id: trailing-whitespace
 -   repo: https://github.com/PyCQA/pylint
-    rev: v3.0.0a7
+    rev: v2.17.5
     hooks:
     - id: pylint
       stages: [commit]


### PR DESCRIPTION
Roll back the version of PyLint used in the pre-commit checks, from an alpha version to a stable release version