### PR TITLE
Get PR checks running again

### DIFF
--- a/.github/workflows/mytardis_ingestion.yml
+++ b/.github/workflows/mytardis_ingestion.yml
@@ -3,7 +3,7 @@ name: Test and Lint MyTardis Ingestion
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
 * [Contact](#contact)
   [Change Log](#change-log)
 
-![master](https://github.com/UoA-eResearch/mytardis_ingestion/actions/workflows/mytardis_ingestion.yml/badge.svg)
-[![codecov](https://codecov.io/gh/UoA-eResearch/mytardis_ingestion/branch/master/graph/badge.svg?token=GEI8FW6T1W)](https://codecov.io/gh/UoA-eResearch/mytardis_ingestion)
+![main](https://github.com/UoA-eResearch/mytardis_ingestion/actions/workflows/mytardis_ingestion.yml/badge.svg)
+[![codecov](https://codecov.io/gh/UoA-eResearch/mytardis_ingestion/branch/main/graph/badge.svg?token=GEI8FW6T1W)](https://codecov.io/gh/UoA-eResearch/mytardis_ingestion)
 ![interrogate](interrogate_badge.svg)
 ![lastcommit](https://img.shields.io/github/last-commit/UoA-eResearch/mytardis_ingestion/badge.svg)
 

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Feature
 
 .. image:: https://github.com/UoA-eResearch/mytardis_ingestion/actions/workflows/mytardis_ingestion.yml/badge.svg
 
-.. image:: https://codecov.io/gh/UoA-eResearch/mytardis_ingestion/branch/master/graph/badge.svg?token=GEI8FW6T1W
+.. image:: https://codecov.io/gh/UoA-eResearch/mytardis_ingestion/branch/main/graph/badge.svg?token=GEI8FW6T1W
       :target: https://codecov.io/gh/UoA-eResearch/mytardis_ingestion
 
 .. image:: https://img.shields.io/github/last-commit/UoA-eResearch/mytardis_ingestion   :alt: GitHub last commit


### PR DESCRIPTION
When we shifted to working off `main` instead of `master`, some references to the master branch in the repo were missed.

Most significantly, in the configuration for GitHub actions, it still says `master`, and so the checks do not appear to be running on PRs into `main`.