### PR TITLE
Support manual and scheduled triggering of the test job

### DIFF
--- a/.github/workflows/mytardis_ingestion.yml
+++ b/.github/workflows/mytardis_ingestion.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+  # Run on main every day at 5am
+  schedule:
+      - cron: '0 5 * * *'
+  # Allow manual triggering through GitHub
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
In the GitHub Actions, add extra triggers, for two purposes:
- `workflow_dispatch` allows the test job to be triggered manually in the GitHub UI
- `schedule` causes the job to run regularly (once per day at 5am in this case)