### PR TITLE
Run formatting checks in PR with Black and isort

### DIFF
--- a/.github/workflows/mytardis_ingestion.yml
+++ b/.github/workflows/mytardis_ingestion.yml
@@ -31,13 +31,19 @@ jobs:
       run: poetry install
       if: steps.cache.outputs.cache-hit != 'true'
 
-    - name: Run pytest
+    - name: isort - check import formatting
+      run: PYTHONPATH=src/ poetry run python -m isort --check --diff --profile black src
+
+    - name: Black - check code formatting
+      run: PYTHONPATH=src/ poetry run python -m black --check --diff src
+
+    - name: pytest - run the tests
       run: PYTHONPATH=src/ poetry run python -m pytest -v --cov=src/ tests/
 
     - name: Run Coverage
       run: PYTHONPATH=src/ poetry run python -m coverage report -m;
 
-    - name: Generate XML Report
+    - name: Generate test coverage XML Report
       run: PYTHONPATH=src/ poetry run python -m coverage xml
 
     - name: Upload Coverage to Codecov
@@ -45,15 +51,9 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
-    - name: Run pylint
+    - name: pylint - static code analysis
       run: PYTHONPATH=src/ poetry run python -m pylint src/ --rcfile .pylintrc
 
-    - name: Run mypy
+    - name: mypy - static type checking
       # Takes configuration from pyproject.toml
       run: PYTHONPATH=src/ poetry run python -m mypy
-
-    - name: Check import formatting with isort
-      run: PYTHONPATH=src/ poetry run python -m isort --check --diff --profile black src
-
-    - name: Check code formatting with Black
-      run: PYTHONPATH=src/ poetry run python -m black --check --diff src


### PR DESCRIPTION
As part of the PR checks, we will now run Black and isort to check that the code is formatted correctly (these are already used in the pre-commit hooks).

Both are run in `--check` mode, so they will not make changes to source files, but if they _would_ normally make changes, the program will return an exit code of 1, causing the checks pipeline to fail.

Additionally, the `--diff` flag is passed, so if there are changes that would be made, these are reported on the command-line, for usability.