### PR TITLE
Use a persistent session when making requests

### DIFF
--- a/src/helpers/mt_rest.py
+++ b/src/helpers/mt_rest.py
@@ -74,7 +74,7 @@ class MyTardisRESTFactory(metaclass=Singleton):  # pylint: disable=R0903
         self.verify_certificate = connection.verify_certificate
         self.api_template = urljoin(connection.hostname, "/api/v1/")
         self.user_agent = f"{self.user_agent_name}/2.0 ({self.user_agent_url})"
-        self._session: Optional[requests.Session] = None
+        self._session = requests.Session()
 
     @backoff.on_exception(backoff.expo, BadGateWayException, max_tries=8)
     def mytardis_api_request(
@@ -114,9 +114,6 @@ class MyTardisRESTFactory(metaclass=Singleton):  # pylint: disable=R0903
         if method == "POST" and url[-1] != "/":
             url = f"{url}/"
 
-        if self._session is None:
-            self._session = requests.Session()
-
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
@@ -124,29 +121,19 @@ class MyTardisRESTFactory(metaclass=Singleton):  # pylint: disable=R0903
         }
         if extra_headers:
             headers = {**headers, **extra_headers}
-        if self.proxies:
-            response = self._session.request(
-                method,
-                url,
-                data=data,
-                params=params,
-                headers=headers,
-                auth=self.auth,
-                verify=self.verify_certificate,
-                proxies=self.proxies,
-                timeout=5,
-            )
-        else:
-            response = self._session.request(
-                method,
-                url,
-                data=data,
-                params=params,
-                headers=headers,
-                auth=self.auth,
-                verify=self.verify_certificate,
-                timeout=5,
-            )
+
+        response = self._session.request(
+            method,
+            url,
+            data=data,
+            params=params,
+            headers=headers,
+            auth=self.auth,
+            verify=self.verify_certificate,
+            proxies=self.proxies,
+            timeout=5,
+        )
+
         if response.status_code == 502:
             raise BadGateWayException(response)
         response.raise_for_status()

--- a/tests/test_mt_rest.py
+++ b/tests/test_mt_rest.py
@@ -44,7 +44,7 @@ def test_mytardis_rest_factory_setup(
     )
 
 
-@mock.patch("requests.request")
+@mock.patch("requests.Session.request")
 def test_backoff_on_mytardis_rest_factory_doesnt_trigger_on_httperror(
     mock_requests_request: Any, auth: AuthConfig, connection: ConnectionConfig
 ) -> None:
@@ -57,7 +57,7 @@ def test_backoff_on_mytardis_rest_factory_doesnt_trigger_on_httperror(
         assert mock_requests_request.call_count == 1
 
 
-@mock.patch("requests.request")
+@mock.patch("requests.Session.request")
 @pytest.mark.long
 def test_backoff_on_mytardis_rest_factory(
     mock_requests_request: Any, auth: AuthConfig, connection: ConnectionConfig


### PR DESCRIPTION
Change the MyTardis client class (MyTardisRESTFactory) so that it creates a requests `Session` object on construction, and uses this session for all of its requests. This speeds up requests, as otherwise, usng the default `requests.request(...)`, a new HTTP connection is created every time a request is made.

It's worth noting that the session object is not just for persisting the HTTP connection; it also persists cookies etc. It seems unlikely this would cause problems, and I haven't seen any.

Documentation for the `Session` object can be found here:
https://requests.readthedocs.io/en/latest/user/advanced/