### PR TITLE
Move the definition of StorageTypesEnum to fix a circular import dependency issue.

### DIFF
--- a/src/blueprints/project.py
+++ b/src/blueprints/project.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 
 from src.blueprints.common_models import GroupACL, ParameterSet, UserACL
 from src.blueprints.custom_data_types import URI, ISODateTime, MTUrl, Username
-from src.config.config import StorageTypesEnum
+from src.blueprints.storage_boxes import StorageTypesEnum
 from src.helpers.enumerators import DataClassification
 
 

--- a/src/blueprints/storage_boxes.py
+++ b/src/blueprints/storage_boxes.py
@@ -1,12 +1,21 @@
 # pylint: disable=too-few-public-methods,no-name-in-module
 """ Pydantic model to hold storage box from MyTardis"""
 
+from enum import Enum
 from pathlib import Path
 from typing import Dict, Optional
 
 from pydantic import BaseModel, ValidationInfo, field_validator
 
 from src.blueprints.custom_data_types import URI
+
+
+class StorageTypesEnum(Enum):
+    """An enumerator to host the different storage types that can be used by
+    MyTardis"""
+
+    FILE_SYSTEM = "file_system"
+    S3 = "s3"
 
 
 class RawStorageBox(BaseModel):

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -12,7 +12,6 @@ the environment automatically and verifies their types and values.
 
 import logging
 from abc import ABC
-from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional
 from urllib.parse import urljoin
@@ -23,17 +22,10 @@ from requests import PreparedRequest
 from requests.auth import AuthBase
 
 from src.blueprints.custom_data_types import MTUrl
+from src.blueprints.storage_boxes import StorageTypesEnum
 from src.helpers.enumerators import MyTardisObject
 
 logger = logging.getLogger(__name__)
-
-
-class StorageTypesEnum(Enum):
-    """An enumerator to host the different storage types that can be used by
-    MyTardis"""
-
-    FILE_SYSTEM = "file_system"
-    S3 = "s3"
 
 
 class GeneralConfig(BaseModel):

--- a/src/smelters/smelt_storage_boxes.py
+++ b/src/smelters/smelt_storage_boxes.py
@@ -12,7 +12,8 @@ from src.blueprints.project import (
     ProjectS3StorageBox,
     ProjectStorageBox,
 )
-from src.config.config import StorageBoxConfig, StorageTypesEnum
+from src.blueprints.storage_boxes import StorageTypesEnum
+from src.config.config import StorageBoxConfig
 
 
 def create_storage_box(

--- a/tests/fixtures/fixtures_archive_app.py
+++ b/tests/fixtures/fixtures_archive_app.py
@@ -9,7 +9,7 @@ from pytest import fixture
 from slugify import slugify
 
 from src.blueprints.project import ProjectFileSystemStorageBox, ProjectS3StorageBox
-from src.config.config import StorageTypesEnum
+from src.blueprints.storage_boxes import StorageTypesEnum
 
 
 @fixture

--- a/tests/fixtures/fixtures_config_from_env.py
+++ b/tests/fixtures/fixtures_config_from_env.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 
 from pytest import fixture
 
+from src.blueprints.storage_boxes import StorageTypesEnum
 from src.config.config import (
     AuthConfig,
     ConfigFromEnv,
@@ -16,7 +17,6 @@ from src.config.config import (
     SchemaConfig,
     StorageBoxConfig,
     StorageConfig,
-    StorageTypesEnum,
 )
 
 

--- a/tests/fixtures/fixtures_constants.py
+++ b/tests/fixtures/fixtures_constants.py
@@ -10,7 +10,7 @@ from pytz import BaseTzInfo
 
 from src.blueprints.common_models import GroupACL, Parameter, UserACL
 from src.blueprints.custom_data_types import URI, ISODateTime, Username
-from src.config.config import StorageTypesEnum
+from src.blueprints.storage_boxes import StorageTypesEnum
 from src.helpers.enumerators import DataClassification
 
 


### PR DESCRIPTION
Move the definition of `StorageTypesEnum` to fix a circular import dependency issue.

The definition shifts from the `config` module to the `blueprints` module. The issue arose because in `config.py` we import from modules under `blueprints`, while in `project.py` (under `blueprints`), we imported `StorageBoxEnum` from `config.py`.

Suggestions welcome for a better location for `StorageTypesEnum`.