### PR TITLE
Fix the broken recording of URIs in IngestionFactory

### DIFF
--- a/src/ingestion_factory/factory.py
+++ b/src/ingestion_factory/factory.py
@@ -153,15 +153,8 @@ class IngestionFactory(metaclass=Singleton):
                 result.error.append(name)
                 continue
 
-            forged_project = self.forge.forge_project(
-                prepared_project, refined_parameters
-            )
-            # TODO: This is a temporary fix for TypeError.
-            # Might need to use isinstance() rather than type() for a typecheck.
-            if type(forged_project) == URI:
-                result.success.append((name, forged_project))
-            else:
-                result.success.append((name, None))
+            project_uri = self.forge.forge_project(prepared_project, refined_parameters)
+            result.success.append((name, project_uri))
 
         logger.info(
             "Successfully ingested %d projects: %s", len(result.success), result.success
@@ -210,15 +203,10 @@ class IngestionFactory(metaclass=Singleton):
                 result.error.append(name)
                 continue
 
-            forged_experiment = self.forge.forge_experiment(
+            experiment_uri = self.forge.forge_experiment(
                 prepared_experiment, refined_parameters
             )
-            # TODO: This is a temporary fix for TypeError.
-            # Might need to use isinstance() rather than type() for a typecheck.
-            if type(forged_experiment) == URI:
-                result.success.append((name, forged_experiment))
-            else:
-                result.success.append((name, None))
+            result.success.append((name, experiment_uri))
 
         logger.info(
             "Successfully ingested %d experiments: %s",
@@ -267,15 +255,8 @@ class IngestionFactory(metaclass=Singleton):
                 result.error.append(name)
                 continue
 
-            forged_dataset = self.forge.forge_dataset(
-                prepared_dataset, refined_parameters
-            )
-            # TODO: This is a temporary fix for TypeError.
-            # Might need to use isinstance() rather than type() for a typecheck.
-            if type(forged_dataset) == URI:
-                result.success.append((name, forged_dataset))
-            else:
-                result.success.append((name, None))
+            dataset_uri = self.forge.forge_dataset(prepared_dataset, refined_parameters)
+            result.success.append((name, dataset_uri))
 
         logger.info(
             "Successfully ingested %d datasets: %s", len(result.success), result.success


### PR DESCRIPTION
In the `IngestionFactory`, when we make calls to `forge_project()`, `forge_experiment()`, and `forge_dataset()`, we have been checking that the returned URI objects are of type `URI`, and if the object does not have this type, then we don't record it in the `IngestionResult`.

However, this check is flawed, because `URI` is not a proper type - it is defined using `typing.Alias`, and its type is `typing._AnnotatedAlias`, which is effectively a `str` with some extra attributes. So `type()` will not report the type as `URI`, nor will `isinstance()` match the object with `URI`.

Instead, since these function insterfaces report that they return a URI, we should assume the outputs are valid, or an exception would already have been raised.