### PR TITLE
IDS-309: Upgrade the codecov action to v3 from the deprecated v1

### DIFF
--- a/.github/workflows/mytardis_ingestion.yml
+++ b/.github/workflows/mytardis_ingestion.yml
@@ -47,7 +47,7 @@ jobs:
       run: PYTHONPATH=src/ poetry run python -m coverage xml
 
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
We use the `codecov-action` in GitHub for uploading code coverage results. Currently we are using v1, but this was deprecated last year (see link below). This upgrades us to the latest stable release (v3).

https://github.com/codecov/codecov-action?tab=readme-ov-file
https://about.codecov.io/blog/introducing-codecovs-new-uploader/