### PR TITLE
Add generic ingestion CLI and refactor profiles

### DIFF
--- a/samples/generic_extraction_and_ingestion.py
+++ b/samples/generic_extraction_and_ingestion.py
@@ -82,7 +82,7 @@ def main():
     beneficiation = Beneficiation(profile_loader.load_custom_beneficiation)
 
     ext_plant = ExtractionPlant(prospector, miner, beneficiation)
-    ingestible_dataclasses = ext_plant.run_extraction(pth)
+    ingestible_dataclasses = ext_plant.extract(pth)
     #  ingestibles = ext_plant.run_extraction(pth, bc.JSON_FORMAT) #for json files
 
     # Start conveyor to transfer datafiles.

--- a/samples/ingestion_biru_example.py
+++ b/samples/ingestion_biru_example.py
@@ -76,7 +76,7 @@ def ingest_data(yaml_pth: Path, rsync_pth: Path) -> None:
     beneficiation = Beneficiation(profile_loader.load_custom_beneficiation())
 
     ext_plant = ExtractionPlant(prospector, miner, beneficiation)
-    ingestible_dataclasses = ext_plant.run_extraction(yaml_pth)
+    ingestible_dataclasses = ext_plant.extract(yaml_pth)
 
     # Ingestion Factory
     mt_rest = MyTardisRESTFactory(config.auth, config.connection)

--- a/src/beneficiations/beneficiation.py
+++ b/src/beneficiations/beneficiation.py
@@ -14,7 +14,6 @@ from typing import Any, Dict
 
 from src.beneficiations.abstract_custom_beneficiation import AbstractCustomBeneficiation
 from src.extraction.ingestibles import IngestibleDataclasses
-from src.utils.types.singleton import Singleton
 
 # ---Constants
 logger = logging.getLogger(__name__)
@@ -22,7 +21,7 @@ logger.setLevel(logging.DEBUG)
 
 
 # ---Code
-class Beneficiation(metaclass=Singleton):
+class Beneficiation:
     """
     This class provides a means of beneficiating project, experiment, dataset and datafile files.
     It takes a list of files in the specified format and parses them into a dictionary of objects.

--- a/src/extraction/extraction_plant.py
+++ b/src/extraction/extraction_plant.py
@@ -7,14 +7,14 @@ Pre-ingestion_factory tasks include prospecting, mining, and beneficiation.
 # ---Imports
 import logging
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Optional
 
 from src.beneficiations.beneficiation import Beneficiation
 from src.extraction.ingestibles import IngestibleDataclasses
+from src.extraction.metadata_extractor import IMetadataExtractor
 from src.extraction.output_manager import OutputManager
 from src.miners.miner import Miner
 from src.prospectors.prospector import Prospector
-from src.utils.types.singleton import Singleton
 
 # ---Constants
 logger = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ logger.setLevel(logging.DEBUG)
 
 
 # ---Code
-class ExtractionPlant(metaclass=Singleton):
+class ExtractionPlant(IMetadataExtractor):
     """Used for extracting data from a given profile and path. Involves prospecting, mining and beneficiating.
     Prospecting is used to check and filter out data and metadata files that can be staged for ingestion.
     Mining is used to generate metadata files that contain fields compatible with the raw dataclasses.
@@ -31,8 +31,8 @@ class ExtractionPlant(metaclass=Singleton):
 
     def __init__(
         self,
-        prospector: Union[Prospector, None],
-        miner: Union[Miner, None],
+        prospector: Optional[Prospector],
+        miner: Optional[Miner],
         beneficiation: Beneficiation,
     ) -> None:
         """Initializes an ExtractionPlant instance with the given parameters.
@@ -50,9 +50,7 @@ class ExtractionPlant(metaclass=Singleton):
         self.miner = miner
         self.beneficiation = beneficiation
 
-    def run_extraction(
-        self, pth: Path, ingest_dict: Optional[Dict[str, list[Any]]] = None
-    ) -> IngestibleDataclasses:
+    def extract(self, root_dir: Path) -> IngestibleDataclasses:
         """Runs the full extraction process on the given path and file format. In the absence of a custom prospector in the
         prospector singleton and a custom miner in the miner singleton, the prospector and the miner will be skipped as this
         assumes the IDW was used.
@@ -71,15 +69,12 @@ class ExtractionPlant(metaclass=Singleton):
         ing_dclasses = IngestibleDataclasses()
 
         if self.prospector and self.prospector.custom_prospector:
-            out_man = self._prospect(pth, out_man)
+            out_man = self._prospect(root_dir, out_man)
 
         if self.miner and self.miner.custom_miner:
-            out_man = self._mine(pth, out_man)
+            out_man = self._mine(root_dir, out_man)
 
-        if not ingest_dict:
-            ingest_dict = out_man.metadata_files_to_ingest_dict
-        # ingestible_dataclasses_out = self._beneficiate(ingest_dict, ing_dclasses) # Libby: changed to below
-        ingestible_dataclasses_out = self._beneficiate(pth, ing_dclasses)
+        ingestible_dataclasses_out = self._beneficiate(root_dir, ing_dclasses)
         return ingestible_dataclasses_out
 
     def _prospect(

--- a/src/extraction/extraction_plant.py
+++ b/src/extraction/extraction_plant.py
@@ -23,10 +23,18 @@ logger.setLevel(logging.DEBUG)
 
 # ---Code
 class ExtractionPlant(IMetadataExtractor):
-    """Used for extracting data from a given profile and path. Involves prospecting, mining and beneficiating.
-    Prospecting is used to check and filter out data and metadata files that can be staged for ingestion.
-    Mining is used to generate metadata files that contain fields compatible with the raw dataclasses.
-    Beneficiating is used to parse the generated metadata files into the raw dataclasses.
+    """An implementation of the IMetadataExtractor interface, designed for the case where
+    metadata extraction has been implemented in separate "Prospect->Mine->Beneficiate" stages,
+    or a subset of those.
+
+    - Prospecting is used to check and filter out data and metadata files that can be staged for
+    ingestion.
+    - Mining is used to generate metadata files that contain fields compatible with the raw
+    dataclasses.
+    - Beneficiating is used to parse the generated metadata files into the raw dataclasses.
+
+    Note: If these more granular stages aren't needed, it is preferable to produce a separate
+    implementation of IMetadataExtractor directly.
     """
 
     def __init__(

--- a/src/extraction/metadata_extractor.py
+++ b/src/extraction/metadata_extractor.py
@@ -1,0 +1,18 @@
+"""Defines an interface for extracting metadata from a directory.
+"""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from src.extraction.ingestibles import IngestibleDataclasses
+
+
+class IMetadataExtractor(ABC):
+    """Abstract Base Class defining an interface for extracting metadata from a directory
+    and parsing it into an ingestible format.
+    """
+
+    @abstractmethod
+    def extract(self, root_dir: Path) -> IngestibleDataclasses:
+        """Extract the data from root_dir and parse into an ingestible format."""
+        raise NotImplementedError("Extraction behaviour must be defined in a subclass.")

--- a/src/ingestion.py
+++ b/src/ingestion.py
@@ -5,8 +5,10 @@ Ingestion runner for the ABI MuSIC data
 import io
 import logging
 from pathlib import Path
+from typing import Optional
 
 import typer
+from typing_extensions import Annotated
 
 from src.config.config import ConfigFromEnv
 from src.conveyor.conveyor import Conveyor
@@ -19,11 +21,37 @@ from src.utils.timing import Timer
 
 
 def main(
-    data_root: Path,
-    storage_dir: Path,
-    profile_name: str,
-    profile_version: str,
-    log_file: Path = Path("ingestion.log"),
+    data_root: Annotated[
+        Path,
+        typer.Argument(help="Directory containing the data to be extracted"),
+    ],
+    storage_dir: Annotated[
+        Path,
+        typer.Argument(help="Directory where the extracted data will be stored"),
+    ],
+    profile_name: Annotated[
+        str,
+        typer.Argument(
+            help="Name of the ingestion profile to be used to extract the data"
+        ),
+    ],
+    profile_version: Optional[
+        Annotated[
+            str,
+            typer.Argument(
+                help=(
+                    "Version of the profile to be used. If left unspecified, the latest "
+                    "will be used"
+                )
+            ),
+        ]
+    ] = None,
+    log_file: Optional[
+        Annotated[
+            Path,
+            typer.Argument(help="Name to be used for the log file"),
+        ]
+    ] = Path("ingestion.log"),
 ) -> None:
     """
     Run an ingestion

--- a/src/ingestion.py
+++ b/src/ingestion.py
@@ -35,22 +35,15 @@ def main(
             help="Name of the ingestion profile to be used to extract the data"
         ),
     ],
-    profile_version: Optional[
-        Annotated[
-            str,
-            typer.Argument(
-                help=(
-                    "Version of the profile to be used. If left unspecified, the latest "
-                    "will be used"
-                )
-            ),
-        ]
+    profile_version: Annotated[
+        Optional[str],
+        typer.Argument(
+            help="Version of the profile to be used. If left unspecified, the latest will be used"
+        ),
     ] = None,
-    log_file: Optional[
-        Annotated[
-            Path,
-            typer.Argument(help="Name to be used for the log file"),
-        ]
+    log_file: Annotated[
+        Optional[Path],
+        typer.Argument(help="Path to be used for the log file"),
     ] = Path("ingestion.log"),
 ) -> None:
     """

--- a/src/ingestion.py
+++ b/src/ingestion.py
@@ -69,11 +69,9 @@ def main(
     logging.info("Finished submitting dataclasses to MyTardis")
     logging.info("Total time (s): %.2f", elapsed)
 
-    datafiles = metadata.get_datafiles()
     transport = RsyncTransport(Path(storage_dir))
     conveyor = Conveyor(transport)
-    conveyor_process = conveyor.initiate_transfer(data_root, datafiles)
-    conveyor_process.join()
+    conveyor.initiate_transfer(data_root, metadata.get_datafiles()).join()
 
 
 if __name__ == "__main__":

--- a/src/ingestion.py
+++ b/src/ingestion.py
@@ -33,14 +33,13 @@ def main(
 
     timer = Timer(start=True)
 
-    root_dir = DirectoryNode(data_root)
-    if root_dir.empty():
+    if DirectoryNode(data_root).empty():
         raise ValueError("Data root directory is empty. May not be mounted.")
 
     profile = load_profile(profile_name, profile_version)
 
     extractor = profile.get_extractor()
-    metadata = extractor.extract(root_dir.path())
+    metadata = extractor.extract(data_root)
 
     logging.info("Number of datafiles: %d", len(metadata.get_datafiles()))
 

--- a/src/ingestion.py
+++ b/src/ingestion.py
@@ -1,5 +1,5 @@
 """
-Ingestion runner for the ABI MuSIC data
+CLI frontend for extracting metadata, and ingesting it with the data into MyTardis.
 """
 
 import io

--- a/src/ingestion.py
+++ b/src/ingestion.py
@@ -16,9 +16,9 @@ from src.utils.filesystem.filesystem_nodes import DirectoryNode
 from src.utils.timing import Timer
 
 
-def main(data_root: Path, log_file: Path = Path("abi_ingestion.log")) -> None:
+def main(data_root: Path, log_file: Path = Path("ingestion.log")) -> None:
     """
-    Run an ingestion for the ABI MuSIC data
+    Run an ingestion
     """
     log_utils.init_logging(file_name=str(log_file), level=logging.DEBUG)
     config = ConfigFromEnv()

--- a/src/profiles/abi_music/parsing.py
+++ b/src/profiles/abi_music/parsing.py
@@ -17,6 +17,7 @@ from src.blueprints.dataset import RawDataset
 from src.blueprints.experiment import RawExperiment
 from src.blueprints.project import RawProject
 from src.extraction.ingestibles import IngestibleDataclasses
+from src.extraction.metadata_extractor import IMetadataExtractor
 from src.mytardis_client.enumerators import DataClassification
 from src.profiles.abi_music.abi_music_consts import (
     ABI_MUSIC_DATASET_RAW_SCHEMA,
@@ -381,3 +382,14 @@ def parse_data(root: DirectoryNode) -> IngestibleDataclasses:
         datasets=dc_raw.get_datasets() + dc_zarr.get_datasets(),
         datafiles=dc_raw.get_datafiles() + dc_zarr.get_datafiles(),
     )
+
+
+class ABIMusicExtractor(IMetadataExtractor):
+    """Metadata extractor for the ABI MuSIC data"""
+
+    def __init__(self) -> None:
+        pass
+
+    def extract(self, root_dir: Path) -> IngestibleDataclasses:
+        root = DirectoryNode(root_dir)
+        return parse_data(root)

--- a/src/profiles/abi_music/profile.py
+++ b/src/profiles/abi_music/profile.py
@@ -2,6 +2,8 @@
 Ingestion profile for the "ABI MuSIC" Microscope
 """
 
+from typing import Optional
+
 from src.extraction.metadata_extractor import IMetadataExtractor
 from src.profiles.abi_music.parsing import ABIMusicExtractor
 from src.profiles.profile_base import IProfile
@@ -21,10 +23,11 @@ class AbiMusicProfile(IProfile):
         return ABIMusicExtractor()
 
 
-def get_profile(version: str) -> IProfile:
+def get_profile(version: Optional[str]) -> IProfile:
     """Entry point for the profile - returns the profile corresponding to the requested version"""
+
     match version:
-        case "v1":
+        case "v1" | None:
             return AbiMusicProfile()
         case _:
             raise ValueError(f"Unknown version '{version}' for 'ABI MuSIC' profile")

--- a/src/profiles/abi_music/profile.py
+++ b/src/profiles/abi_music/profile.py
@@ -21,7 +21,7 @@ class AbiMusicProfile(IProfile):
         return ABIMusicExtractor()
 
 
-def load_profile(version: str) -> IProfile:
+def get_profile(version: str) -> IProfile:
     """Entry point for the profile - returns the profile corresponding to the requested version"""
     match version:
         case "v1":

--- a/src/profiles/abi_music/profile.py
+++ b/src/profiles/abi_music/profile.py
@@ -1,0 +1,26 @@
+"""
+Ingestion profile for the "ABI MuSIC" Microscope
+"""
+
+from src.extraction.metadata_extractor import IMetadataExtractor
+from src.profiles.abi_music.parsing import ABIMusicExtractor
+from src.profiles.profile_base import IProfile
+
+
+class AbiMusicProfile(IProfile):
+    """Profile defining the ingestion behaviour for the 'ABI MuSIC' Microscope"""
+
+    def __init__(self) -> None:
+        pass
+
+    def get_extractor(self) -> IMetadataExtractor:
+        return ABIMusicExtractor()
+
+
+def load_profile(version: str) -> IProfile:
+    """Entry point for the profile - returns the profile corresponding to the requested version"""
+    match version:
+        case "v1":
+            return AbiMusicProfile()
+        case _:
+            raise ValueError(f"Unknown version '{version}' for 'ABI MuSIC' profile")

--- a/src/profiles/abi_music/profile.py
+++ b/src/profiles/abi_music/profile.py
@@ -13,6 +13,10 @@ class AbiMusicProfile(IProfile):
     def __init__(self) -> None:
         pass
 
+    @property
+    def name(self) -> str:
+        return "abi_music"
+
     def get_extractor(self) -> IMetadataExtractor:
         return ABIMusicExtractor()
 

--- a/src/profiles/idw/profile.py
+++ b/src/profiles/idw/profile.py
@@ -27,7 +27,7 @@ class IDWProfile(IProfile):
         )
 
 
-def load_profile(version: str) -> IProfile:
+def get_profile(version: str) -> IProfile:
     """Entry point for the profile - returns the profile corresponding to the requested version"""
     match version:
         case "v1":

--- a/src/profiles/idw/profile.py
+++ b/src/profiles/idw/profile.py
@@ -15,6 +15,10 @@ class IDWProfile(IProfile):
     def __init__(self) -> None:
         pass
 
+    @property
+    def name(self) -> str:
+        return "idw"
+
     def get_extractor(self) -> IMetadataExtractor:
         return ExtractionPlant(
             prospector=None,

--- a/src/profiles/idw/profile.py
+++ b/src/profiles/idw/profile.py
@@ -2,6 +2,8 @@
 Ingestion profile for ingestions using the Instrument Data Wizard (IDW)
 """
 
+from typing import Optional
+
 from src.beneficiations.beneficiation import Beneficiation
 from src.extraction.extraction_plant import ExtractionPlant
 from src.extraction.metadata_extractor import IMetadataExtractor
@@ -27,10 +29,10 @@ class IDWProfile(IProfile):
         )
 
 
-def get_profile(version: str) -> IProfile:
+def get_profile(version: Optional[str]) -> IProfile:
     """Entry point for the profile - returns the profile corresponding to the requested version"""
     match version:
-        case "v1":
+        case "v1" | None:
             return IDWProfile()
         case _:
             raise ValueError(f"Unknown version '{version}' for 'IDW' profile")

--- a/src/profiles/idw/profile.py
+++ b/src/profiles/idw/profile.py
@@ -5,7 +5,7 @@ Ingestion profile for ingestions using the Instrument Data Wizard (IDW)
 from src.beneficiations.beneficiation import Beneficiation
 from src.extraction.extraction_plant import ExtractionPlant
 from src.extraction.metadata_extractor import IMetadataExtractor
-from src.profiles.idw.custom_beneficiation import CustomBeneficiation
+from src.profiles.idw.custom_beneficiation import CustomBeneficiation  # type: ignore
 from src.profiles.profile_base import IProfile
 
 

--- a/src/profiles/idw/profile.py
+++ b/src/profiles/idw/profile.py
@@ -1,0 +1,32 @@
+"""
+Ingestion profile for ingestions using the Instrument Data Wizard (IDW)
+"""
+
+from src.beneficiations.beneficiation import Beneficiation
+from src.extraction.extraction_plant import ExtractionPlant
+from src.extraction.metadata_extractor import IMetadataExtractor
+from src.profiles.idw.custom_beneficiation import CustomBeneficiation
+from src.profiles.profile_base import IProfile
+
+
+class IDWProfile(IProfile):
+    """Profile defining the ingestion behaviour for metadata from the Instrument Data Wizard"""
+
+    def __init__(self) -> None:
+        pass
+
+    def get_extractor(self) -> IMetadataExtractor:
+        return ExtractionPlant(
+            prospector=None,
+            miner=None,
+            beneficiation=Beneficiation(beneficiation=CustomBeneficiation()),
+        )
+
+
+def load_profile(version: str) -> IProfile:
+    """Entry point for the profile - returns the profile corresponding to the requested version"""
+    match version:
+        case "v1":
+            return IDWProfile()
+        case _:
+            raise ValueError(f"Unknown version '{version}' for 'IDW' profile")

--- a/src/profiles/profile_base.py
+++ b/src/profiles/profile_base.py
@@ -11,6 +11,12 @@ from src.extraction.metadata_extractor import IMetadataExtractor
 class IProfile(ABC):
     """Abstract base class defining the interface for an ingestion profile"""
 
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Get the name of this profile"""
+        raise NotImplementedError("Concrete implementations must specify their name")
+
     @abstractmethod
     def get_extractor(self) -> IMetadataExtractor:
         """Get the metadata extractor associated with this profile"""

--- a/src/profiles/profile_base.py
+++ b/src/profiles/profile_base.py
@@ -1,0 +1,17 @@
+"""
+Interface for ingestion profiles, which define the specific ingestion behaviour for
+different groups and/or instruments.
+"""
+
+from abc import ABC, abstractmethod
+
+from src.extraction.metadata_extractor import IMetadataExtractor
+
+
+class IProfile(ABC):
+    """Abstract base class defining the interface for an ingestion profile"""
+
+    @abstractmethod
+    def get_extractor(self) -> IMetadataExtractor:
+        """Get the metadata extractor associated with this profile"""
+        raise NotImplementedError("No metadata extractor has been implemented")

--- a/src/profiles/profile_register.py
+++ b/src/profiles/profile_register.py
@@ -1,0 +1,52 @@
+"""
+A register for all ingestion profiles that can be loaded, and the entry point
+for loading profiles.
+"""
+
+import importlib
+
+from src.profiles.profile_base import IProfile
+
+_PROFILE_ROOT = "src.profiles."
+
+"""
+This is the record of all profiles, and the location of the module
+which is the profile's entry point. The module is expected to contain
+a function called 'load_profile()' which takes a version, and returns
+an IProfile object.
+
+To register a new profile, add an entry here.
+"""
+_profiles = {
+    "abi_music": "abi_music.profile",
+}
+
+
+def load_profile(name: str, version: str) -> IProfile:
+    """Load an ingestion profile corresponding to 'name' and 'version'"""
+    profile_location = _profiles.get(name)
+    if profile_location is None:
+        raise ValueError(f"Unknown ingestion profile '{name}'")
+
+    profile_path = _PROFILE_ROOT + profile_location
+
+    try:
+        module = importlib.import_module(profile_path)
+    except ModuleNotFoundError as e:
+        raise RuntimeError(
+            f"Failed to load a profile module from {profile_path} while loading profile {name}"
+        ) from e
+
+    if not hasattr(module, "load_profile"):
+        raise ImportError(
+            f"The module for profile {name} has no 'load_profile()' function"
+        )
+
+    try:
+        profile: IProfile = module.load_profile(version)
+    except Exception as e:
+        raise ImportError(
+            f"An error occurred while loading the profile '{name}'"
+        ) from e
+
+    return profile

--- a/src/profiles/profile_register.py
+++ b/src/profiles/profile_register.py
@@ -23,6 +23,11 @@ _profiles = {
 }
 
 
+def get_profile_names() -> list[str]:
+    """Get a list containing the name of every profile"""
+    return list(_profiles.keys())
+
+
 def load_profile(name: str, version: str) -> IProfile:
     """Load an ingestion profile corresponding to 'name' and 'version'"""
     profile_location = _profiles.get(name)

--- a/src/profiles/profile_register.py
+++ b/src/profiles/profile_register.py
@@ -19,6 +19,7 @@ To register a new profile, add an entry here.
 """
 _profiles = {
     "abi_music": "abi_music.profile",
+    "idw": "idw.profile",
 }
 
 

--- a/src/profiles/profile_register.py
+++ b/src/profiles/profile_register.py
@@ -4,6 +4,7 @@ for loading profiles.
 """
 
 import importlib
+from typing import Optional
 
 from src.profiles.profile_base import IProfile
 
@@ -33,7 +34,7 @@ def get_profile_names() -> list[str]:
     return list(get_profile_register().keys())
 
 
-def load_profile(name: str, version: str) -> IProfile:
+def load_profile(name: str, version: Optional[str] = None) -> IProfile:
     """Load an ingestion profile corresponding to 'name' and 'version'"""
     profile_location = get_profile_register().get(name)
     if profile_location is None:

--- a/src/profiles/profile_register.py
+++ b/src/profiles/profile_register.py
@@ -17,20 +17,25 @@ an IProfile object.
 
 To register a new profile, add an entry here.
 """
-_profiles = {
+_PROFILES = {
     "abi_music": "abi_music.profile",
     "idw": "idw.profile",
 }
 
 
+def get_profile_register() -> dict[str, str]:
+    """Get a register containing all the profiles and their locations."""
+    return _PROFILES
+
+
 def get_profile_names() -> list[str]:
     """Get a list containing the name of every profile"""
-    return list(_profiles.keys())
+    return list(get_profile_register().keys())
 
 
 def load_profile(name: str, version: str) -> IProfile:
     """Load an ingestion profile corresponding to 'name' and 'version'"""
-    profile_location = _profiles.get(name)
+    profile_location = get_profile_register().get(name)
     if profile_location is None:
         raise ValueError(f"Unknown ingestion profile '{name}'")
 

--- a/src/profiles/profile_register.py
+++ b/src/profiles/profile_register.py
@@ -45,11 +45,11 @@ def load_profile(name: str, version: str) -> IProfile:
 
     if not hasattr(module, "load_profile"):
         raise ImportError(
-            f"The module for profile {name} has no 'load_profile()' function"
+            f"The module for profile {name} has no 'get_profile()' function"
         )
 
     try:
-        profile: IProfile = module.load_profile(version)
+        profile: IProfile = module.get_profile(version)
     except Exception as e:
         raise ImportError(
             f"An error occurred while loading the profile '{name}'"

--- a/src/profiles/profile_register.py
+++ b/src/profiles/profile_register.py
@@ -43,7 +43,7 @@ def load_profile(name: str, version: str) -> IProfile:
             f"Failed to load a profile module from {profile_path} while loading profile {name}"
         ) from e
 
-    if not hasattr(module, "load_profile"):
+    if not hasattr(module, "get_profile"):
         raise ImportError(
             f"The module for profile {name} has no 'get_profile()' function"
         )

--- a/tests/ignored/ignoredtest_abi_extraction_plant.py
+++ b/tests/ignored/ignoredtest_abi_extraction_plant.py
@@ -27,7 +27,7 @@ def test_extraction_plant(tmpdir_metadata, get_abi_profile):
     bnfc: Beneficiation = Beneficiation(prof_loader.load_custom_beneficiation())
     ext_plant = ExtractionPlant(prospector, miner, bnfc)
 
-    ingestible_dataclasses = ext_plant.run_extraction(tmpdir_metadata[0])
+    ingestible_dataclasses = ext_plant.extract(tmpdir_metadata[0])
     projs = ingestible_dataclasses.get_projects()
     expts = ingestible_dataclasses.get_experiments()
     dsets = ingestible_dataclasses.get_datasets()
@@ -56,7 +56,7 @@ def test_extraction_plant_no_profile(tmpdir_metadata):
         miner = Miner(prof_loader.load_custom_miner())
         bnfc: Beneficiation = Beneficiation(prof_loader.load_custom_beneficiation())
         ext_plant = ExtractionPlant(prospector, miner, bnfc)
-        ext_plant.run_extraction(tmpdir_metadata[0])
+        ext_plant.extract(tmpdir_metadata[0])
 
     Prospector.clear()
     Miner.clear()

--- a/tests/test_abi_extraction_plant.py
+++ b/tests/test_abi_extraction_plant.py
@@ -28,7 +28,7 @@ def test_extraction_plant(tmpdir_metadata, get_abi_profile):
     bnfc: Beneficiation = Beneficiation(prof_loader.load_custom_beneficiation())
     ext_plant = ExtractionPlant(prospector, miner, bnfc)
 
-    ingestible_dataclasses = ext_plant.run_extraction(tmpdir_metadata[0])
+    ingestible_dataclasses = ext_plant.extract(tmpdir_metadata[0])
     projs = ingestible_dataclasses.get_projects()
     expts = ingestible_dataclasses.get_experiments()
     dsets = ingestible_dataclasses.get_datasets()
@@ -58,7 +58,7 @@ def test_extraction_plant_no_profile(tmpdir_metadata):
         miner = Miner(prof_loader.load_custom_miner())
         bnfc: Beneficiation = Beneficiation(prof_loader.load_custom_beneficiation())
         ext_plant = ExtractionPlant(prospector, miner, bnfc)
-        ext_plant.run_extraction(tmpdir_metadata[0])
+        ext_plant.extract(tmpdir_metadata[0])
 
     Prospector.clear()
     Miner.clear()

--- a/tests/test_profile_common.py
+++ b/tests/test_profile_common.py
@@ -28,7 +28,7 @@ def test_get_profile_names() -> None:
 
 @pytest.fixture(name="mock_profile_info")
 def fixture_mock_profile_info() -> mock.MagicMock:
-    return mock.MagicMock(return_value={"mock_profile": "mock_profile.module.path"})
+    return mock.MagicMock(return_value={"mock_profile": "fake.module.path"})
 
 
 @pytest.fixture(name="mock_profile_module")

--- a/tests/test_profile_common.py
+++ b/tests/test_profile_common.py
@@ -1,0 +1,57 @@
+"""
+Tests for common code related to profiles (not specific profiles)
+"""
+
+# pylint: disable=missing-function-docstring
+
+# import pytest
+
+import mock
+import pytest
+
+from src.profiles.profile_register import (
+    get_profile_names,
+    get_profile_register,
+    load_profile,
+)
+
+
+def test_get_profile_register() -> None:
+    profiles = get_profile_register()
+    assert len(profiles) > 0, "Should return some profiles"
+
+
+def test_get_profile_names() -> None:
+    names = get_profile_names()
+    assert len(names) > 0, "Should return some names"
+
+
+@pytest.fixture(name="mock_profile_info")
+def fixture_mock_profile_info() -> mock.MagicMock:
+    return mock.MagicMock(return_value={"mock_profile": "mock_profile.module.path"})
+
+
+@pytest.fixture(name="mock_profile_module")
+def fixture_mock_profile_module() -> mock.MagicMock:
+    mock_profile = mock.MagicMock()
+    type(mock_profile).name = mock.PropertyMock(return_value="mock_profile")
+
+    mock_module = mock.MagicMock()
+    mock_module.configure_mock(**{"get_profile.return_value": mock_profile})
+
+    return mock_module
+
+
+def test_load_profile(
+    mock_profile_info: mock.MagicMock, mock_profile_module: mock.MagicMock
+) -> None:
+    with mock.patch(
+        "src.profiles.profile_register.get_profile_register", mock_profile_info
+    ):
+        with mock.patch(
+            "importlib.import_module", mock.MagicMock(return_value=mock_profile_module)
+        ):
+            profile = load_profile("mock_profile", "v1")
+
+            mock_profile_module.get_profile.assert_called_once_with("v1")
+            assert profile.name == "mock_profile"

--- a/tests/todo_biru_extraction.py
+++ b/tests/todo_biru_extraction.py
@@ -31,7 +31,7 @@ def test_extraction_plant(tmpdir_metadata, get_abi_profile):
     bnfc: Beneficiation = Beneficiation(prof_loader.load_custom_beneficiation())
     ext_plant = ExtractionPlant(prospector, miner, bnfc)
 
-    ingestible_dataclasses = ext_plant.run_extraction(tmpdir_metadata[0])
+    ingestible_dataclasses = ext_plant.extract(tmpdir_metadata[0])
     projs = ingestible_dataclasses.get_projects()
     expts = ingestible_dataclasses.get_experiments()
     dsets = ingestible_dataclasses.get_datasets()
@@ -61,7 +61,7 @@ def test_extraction_plant_no_profile(tmpdir_metadata):
         miner = Miner(prof_loader.load_custom_miner())
         bnfc: Beneficiation = Beneficiation(prof_loader.load_custom_beneficiation())
         ext_plant = ExtractionPlant(prospector, miner, bnfc)
-        ext_plant.run_extraction(tmpdir_metadata[0])
+        ext_plant.extract(tmpdir_metadata[0])
 
     Prospector.clear()
     Miner.clear()


### PR DESCRIPTION
Convert the ABI Music ingestion-runner script into the beginnings of a generic ingestion-runner script. This involves:

- Moving `src/profiles/abi_music/ingest.py` to `src/ingestion.py`
- Altering the interface for metadata extraction.
  - The script uses a new interface defined in `IMetadataExtractor`, with a requirement to implement an `extract()` method which takes a directory and produces a set of dataclasses.
  - This "extract" step corresponds to the Prospect-Mine-Beneficiate process.
  - New ingestion implementations can either retain the PMB phases by using `ExtractionPlant`, which now implements the `IMetadataExtractor` interface, or can implement the extraction in one step if this is desirable/simpler.
- Changes to the profile-loading
  - The profiles and their locations are now listed in `src/profiles/profile_register.py`, which is more explicit than relying on directory structure and specific file names, and arguably more flexible.
  - There is a new interface for a profile defined in `IProfile`
  - Currently the only extension points are defining a name, and defining the extractor used.
  - To add a new profile now, one needs to add a source file with a `get_profile()` method, which returns an instance of `IProfile` containing the specific profile behaviour, and then add a line in `profile_register.py` declaring the name and module path.
  - This means the profile-loading logic shouldn't need to change if the profile interface changes (currently the `ProfileLoader` has to be updated each time a new profile field/behaviour is added).
  - It also makes the definition of a profile centralised in a single file, rather than spread over multiple files.


The command-line interface is defined using `typer`, which infers the arguments from function arguments
![ingestion_cli](https://github.com/UoA-eResearch/mytardis_ingestion/assets/142769327/90c92911-1952-4bfc-a3c0-4a97c8b15c29)
