### PR TITLE
Ids 522 redefine ro crate as metadata extractor

### DIFF
--- a/samples/ro_crate_ingestion_example.py
+++ b/samples/ro_crate_ingestion_example.py
@@ -8,12 +8,11 @@ from pathlib import Path
 from src.config.config import ConfigFromEnv
 from src.conveyor.conveyor import Conveyor
 from src.conveyor.transports.rsync import RsyncTransport
-from src.extraction.ingestibles import IngestibleDataclasses
 from src.ingestion_factory.factory import IngestionFactory
 from src.mytardis_client.mt_rest import MyTardisRESTFactory
 from src.overseers.overseer import Overseer
 from src.profiles.profile_loader import ProfileLoader
-from src.profiles.ro_crate.ro_crate_parser import ROCrateParser
+from src.profiles.ro_crate.ro_crate_parser import ROCrateExtractor
 from src.smelters.smelter import Smelter
 
 root = logging.getLogger()
@@ -39,18 +38,13 @@ PROFILE_NAME = "ro_crate"
 profile_loader = ProfileLoader(PROFILE_NAME)
 
 
-def ingest_data(
-    ro_crate_path: Path, rsync_pth: Path, crate_to_tardis_schema: Path
-) -> None:
+def ingest_data(ro_crate_path: Path, rsync_pth: Path) -> None:
     """
     Runs the ingestion pipeline.
     """
-    crate_parser = ROCrateParser(
-        ro_crate_path, crate_to_tardis_schema, schema_config=config.default_schema
-    )
+    crate_extractor = ROCrateExtractor()
+    metadata = crate_extractor.extract(ro_crate_path)
     # Extraction Plant
-    ingestible_dataclasses = IngestibleDataclasses()
-    ingestible_dataclasses = crate_parser.run_extraction(ingestible_dataclasses)
 
     # Ingestion Factory
     mt_rest = MyTardisRESTFactory(config.auth, config.connection)
@@ -70,12 +64,12 @@ def ingest_data(
         smelter=smelter,
     )
 
-    factory.ingest_projects(ingestible_dataclasses.get_projects())
-    factory.ingest_experiments(ingestible_dataclasses.get_experiments())
-    factory.ingest_datasets(ingestible_dataclasses.get_datasets())
-    factory.ingest_datafiles(ingestible_dataclasses.get_datafiles())
+    factory.ingest_projects(metadata.get_projects())
+    factory.ingest_experiments(metadata.get_experiments())
+    factory.ingest_datasets(metadata.get_datasets())
+    factory.ingest_datafiles(metadata.get_datafiles())
 
-    datafiles = ingestible_dataclasses.get_datafiles()
+    datafiles = metadata.get_datafiles()
     rsync_transport = RsyncTransport(Path(rsync_pth))
     conveyor = Conveyor(rsync_transport)
     conveyor_process = conveyor.initiate_transfer(Path(ro_crate_path).parent, datafiles)
@@ -93,17 +87,13 @@ if __name__ == "__main__":
             "python ingestion_ro_crate_example.py "
             '"/path/to/ro_crate/data" '
             '"/path/to/the/rsync/destination"'
-            '"/path/to/the/schema/mapping"'
         ),
     )
     parser.add_argument("ro_crate_path", type=str, help="Path to the ro_crate file")
     parser.add_argument("rsync_pth", type=str, help="Path to the rsync destination")
-    parser.add_argument(
-        "schema_path", type=str, help="Path to the ro_crate to my tardis mapping schema"
-    )
 
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(1)
     args = parser.parse_args()
-    ingest_data(args.ro_crate_path, args.rsync_pth, args.schema_path)
+    ingest_data(args.ro_crate_path, args.rsync_pth)

--- a/src/profiles/ro_crate/_consts.py
+++ b/src/profiles/ro_crate/_consts.py
@@ -1,2 +1,8 @@
 """Add profile-specific constants in this module
 """
+CRATE_TO_TARDIS_PROFILE = "src/profiles/ro_crate/test_mapping.json"
+
+RO_CRATE_DATAFILE_SCHEMA = "http://rocrate.testing/datafile/james"
+RO_CRATE_DATASET_SCHEMA = "http://rocrate.testing/dataset/ganglia/1/james"
+RO_CRATE_EXPERIMENT_SCHEMA = "http://rocrate.testing/experiment/1/james"
+RO_CRATE_PROJECT_SCHEMA = "http://rocrate.testing/project/1/james"

--- a/src/profiles/ro_crate/ro_crate_parser.py
+++ b/src/profiles/ro_crate/ro_crate_parser.py
@@ -18,9 +18,9 @@ from rocrate.utils import get_norm_value
 
 from src.blueprints.common_models import GroupACL, UserACL
 from src.blueprints.custom_data_types import validate_isodatetime, validate_url
-from src.blueprints.datafile import RawDatafile
-from src.blueprints.dataset import RawDataset
-from src.blueprints.experiment import RawExperiment
+from src.blueprints.datafile import RawDatafile  # pylint: disable=duplicate-code
+from src.blueprints.dataset import RawDataset  # pylint: disable=duplicate-code
+from src.blueprints.experiment import RawExperiment  # pylint: disable=duplicate-code
 from src.blueprints.project import RawProject  # pylint: disable=duplicate-code
 from src.extraction.ingestibles import IngestibleDataclasses
 from src.extraction.metadata_extractor import (  # pylint: disable=duplicate-code


### PR DESCRIPTION
Added  ROCrateExtractor() class to ro_crate_parser.py in preparation for integrating with new profiles and CLI system.

- Modified test script to use extractor
- moved schema elements from schema.config to _consts
- moved crate_to_tardis mapping from a passed variable to a path in _consts (this path is relative to the root of the repo so might need to be a bit more flexible in future)