### PR TITLE
Ids 520 add ro crate to profile register

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ testenv
 log.txt
 
 .mypy_cache/
+
+ingestion_result.json

--- a/src/ingestion_factory/factory.py
+++ b/src/ingestion_factory/factory.py
@@ -6,7 +6,7 @@ needs to determine the Smelter class that is used by the Factory"""
 import json
 import logging
 import sys
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import ValidationError
 
@@ -325,6 +325,16 @@ class IngestionFactory(metaclass=Singleton):
         datasets_result: IngestionResult | None,
         datafiles_result: IngestionResult | None,
     ) -> None:
+        class IngestionResultEncoder(
+            json.JSONEncoder
+        ):  # pylint: disable=missing-class-docstring
+            def default(
+                self, o: Any
+            ) -> Any:  # pylint:disable=missing-function-docstring
+                if isinstance(o, IngestionResult):
+                    return o.__dict__
+                return json.JSONEncoder.default(self, o)
+
         with open("ingestion_result.json", "w", encoding="utf-8") as file:
             json.dump(
                 {
@@ -336,6 +346,7 @@ class IngestionFactory(metaclass=Singleton):
                 file,
                 ensure_ascii=False,
                 indent=4,
+                cls=IngestionResultEncoder,
             )
 
     def ingest(  # pylint: disable=missing-function-docstring

--- a/src/profiles/profile_register.py
+++ b/src/profiles/profile_register.py
@@ -21,6 +21,7 @@ To register a new profile, add an entry here.
 _PROFILES = {
     "abi_music": "abi_music.profile",
     "idw": "idw.profile",
+    "ro_crate": "ro_crate.profile",
 }
 
 

--- a/src/profiles/ro_crate/_consts.py
+++ b/src/profiles/ro_crate/_consts.py
@@ -1,5 +1,7 @@
 """Add profile-specific constants in this module
 """
+PROFILE_VERSION = "0.1.0"
+
 CRATE_TO_TARDIS_PROFILE = "src/profiles/ro_crate/test_mapping.json"
 
 RO_CRATE_DATAFILE_SCHEMA = "http://rocrate.testing/datafile/james"

--- a/src/profiles/ro_crate/profile.py
+++ b/src/profiles/ro_crate/profile.py
@@ -1,0 +1,34 @@
+"""
+Ingestion profile for ingestions of RO-Crates
+"""
+
+from typing import Optional
+
+from src.extraction.metadata_extractor import IMetadataExtractor
+from src.profiles.profile_base import IProfile
+from src.profiles.ro_crate._consts import PROFILE_VERSION as CRATE_PROFILE_VERSION
+from src.profiles.ro_crate.ro_crate_parser import ROCrateExtractor
+
+
+class ROCrateProfile(IProfile):
+    """Profile defining the ingestion behaviour for metadata from RO-crates"""
+
+    def __init__(self) -> None:
+        pass
+
+    @property
+    def name(self) -> str:
+        return "ro_crate"
+
+    def get_extractor(self) -> IMetadataExtractor:
+        return ROCrateExtractor()
+
+
+def get_profile(version: Optional[str]) -> IProfile:
+    """Entry point for the profile - returns the profile corresponding to the requested version"""
+    if version == CRATE_PROFILE_VERSION or not version:
+        return ROCrateProfile()
+    raise ValueError(
+        f"""Unknown version '{version}' for 'RO_Crate' profile
+        \n Current RO_Crate Profile version is'{CRATE_PROFILE_VERSION}'."""
+    )


### PR DESCRIPTION
Added the RO-Crate extractor to the profile register and CLI interface

In the process I needed to update factory.py to serialize IngestionResult objects as JSON properly as part of dump_ingestion_result_json()

fixed how raw_datafiles are named when read from an RO-Crate to always use their position on disk to work with rsync transport