### PR TITLE
IDS-544: support separate extraction and uploading subcommands in the ingestion CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ toml = "^0.10.2"
 pyproject-pre-commit = "^0.1.4"
 pyfakefs = "^5.3.1"
 
+[tool.poetry.scripts]
+ids = 'src.ingestion:app'
+
 [tool.isort]
 profile = "black"
 

--- a/src/extraction/manifest.py
+++ b/src/extraction/manifest.py
@@ -6,6 +6,7 @@ refinery/ingestion. The raw dataclasses are stored in lists.
 # ---Imports
 from __future__ import annotations
 
+import io
 import logging
 from pathlib import Path
 from typing import List, Optional, Sequence, TextIO, Type, TypeVar
@@ -172,7 +173,9 @@ class IngestionManifest:
             datafiles=datafiles,
         )
 
-    def print(self, stream: TextIO, skip_datafiles: bool = True) -> None:
+    def summarize(self, skip_datafiles: bool = True) -> str:
+        stream = io.StringIO()
+
         def write_header(text: str) -> None:
             stream.write(f"\n\n{'=' * len(text)}\n")
             stream.write(text)
@@ -192,6 +195,10 @@ class IngestionManifest:
         write_header("Datasets")
         write_dataclasses(self.get_datasets())
 
-        if not skip_datafiles:
+        if skip_datafiles:
+            stream.write(f"Number of datafiles: {len(self.get_datafiles())}")
+        else:
             write_header("Datafiles")
             write_dataclasses(self.get_datafiles())
+
+        return stream.getvalue()

--- a/src/ingestion.py
+++ b/src/ingestion.py
@@ -64,7 +64,7 @@ def extract(
     ],
     profile_name: ProfileNameArg,
     profile_version: ProfileVersionArg = None,
-    log_file: LogFileArg = Path("ingestion.log"),
+    log_file: LogFileArg = Path("extraction.log"),
 ) -> None:
     """
     Extract metadata from a directory tree and parse it into a MyTardis PEDD structure.
@@ -104,7 +104,7 @@ def upload(
         Path,
         typer.Argument(help="Directory where the extracted data will be stored"),
     ],
-    log_file: LogFileArg = Path("ingestion.log"),
+    log_file: LogFileArg = Path("upload.log"),
 ) -> None:
     """
     Submit the extracted metadata to MyTardis, and transfer the data to the storage directory.

--- a/src/ingestion.py
+++ b/src/ingestion.py
@@ -2,7 +2,6 @@
 CLI frontend for extracting metadata, and ingesting it with the data into MyTardis.
 """
 
-import io
 import logging
 from pathlib import Path
 from typing import Optional, TypeAlias
@@ -81,20 +80,14 @@ def extract(
     extractor = profile.get_extractor()
     metadata = extractor.extract(data_dir)
 
-    logging.info("Number of datafiles: %d", len(metadata.get_datafiles()))
-
-    # Does this logging still meet our needs?
-    stream = io.StringIO()
-    metadata.print(stream)
-    logging.info(stream.getvalue())
-
     elapsed = timer.stop()
     logging.info("Finished parsing data directory into PEDD hierarchy")
     logging.info("Total time (s): %.2f", elapsed)
+    logging.info(metadata.summarize())
 
     metadata.serialize(output_dir)
 
-    logging.info("Finished. Ingestion manifest written to %s.", output_dir)
+    logging.info("Extraction complete. Ingestion manifest written to %s.", output_dir)
 
 
 @app.command()
@@ -124,16 +117,10 @@ def ingest(
     extractor = profile.get_extractor()
     metadata = extractor.extract(data_root)
 
-    logging.info("Number of datafiles: %d", len(metadata.get_datafiles()))
-
-    # Does this logging still meet our needs?
-    stream = io.StringIO()
-    metadata.print(stream)
-    logging.info(stream.getvalue())
-
     elapsed = timer.stop()
     logging.info("Finished parsing data directory into PEDD hierarchy")
     logging.info("Total time (s): %.2f", elapsed)
+    logging.info(metadata.summarize())
 
     logging.info("Submitting to MyTardis")
     timer.start()


### PR DESCRIPTION
Currently the ingestion CLI always runs the full ingestion pipeline (extract/parse, submit to MyTardis). This PR adds subcommands to the CLI so that the metadata extraction and upload steps can be run separately.

The steps would be:
- `extract`: Run the extraction once (as the parsing needs to be a monolithic process) to produce a serialized collection of dataclasses.
- `upload`: deserialize the dataclasses produced in the `extract` step and submit them to MyTardis.

This provides more flexibility, e.g. you can run the extraction and then inspect the results locally before deciding whether to submit them. It could also help with debugging new profiles, if one is able to run extraction without interacting with MyTardis.

The CLI retains the ability to run the pipeline end-to-end (i.e. the CLI behaviour prior to this PR) via a new `ingest` subcommand.

This PR also adds an alias to the poetry environment for the CLI: "ids". This means e.g. the extraction step can be invoked as follows:
```bash
ids extract /mnt/abi_test_data ~/dev/tmp/abi_extraction_1 abi_music
```
Below are examples of the help messages:
![ids_help](https://github.com/UoA-eResearch/mytardis_ingestion/assets/142769327/00d40d8a-1dd7-4da2-bea5-f8b01b9c72fd)
![ids_extract_help](https://github.com/UoA-eResearch/mytardis_ingestion/assets/142769327/e72c2eee-dd6d-4f70-8e91-750dc0560ae6)
