### PR TITLE
IDS-569: Check if objects have been ingested before submitting to MyTardis

### DIFF
--- a/src/blueprints/datafile.py
+++ b/src/blueprints/datafile.py
@@ -5,7 +5,7 @@ from abc import ABC
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 from src.blueprints.common_models import GroupACL, ParameterSet, UserACL
 from src.blueprints.custom_data_types import URI, MTUrl
@@ -60,6 +60,11 @@ class BaseDatafile(BaseModel, ABC):
     def object_id(self) -> str:
         """Main ID for a datafile"""
         return self.filename
+
+    @field_serializer("directory")
+    def dir_as_posix_path(self, directory: Path) -> str:
+        """Ensures the directory is always serialized as a posix path"""
+        return directory.as_posix()
 
 
 class RawDatafile(BaseDatafile):

--- a/src/blueprints/datafile.py
+++ b/src/blueprints/datafile.py
@@ -47,7 +47,7 @@ class BaseDatafile(BaseModel, ABC):
         delete_date: ISODateTime
             the date that the datafile is able to be deleted"""
 
-    filename: str
+    filename: str = Field(min_length=1)
     directory: Path
     md5sum: str
     mimetype: str
@@ -55,6 +55,11 @@ class BaseDatafile(BaseModel, ABC):
     users: Optional[List[UserACL]] = None
     groups: Optional[List[GroupACL]] = None
     data_status: Optional[DataStatus] = None
+
+    @property
+    def object_id(self) -> str:
+        """Main ID for a datafile"""
+        return self.filename
 
 
 class RawDatafile(BaseDatafile):

--- a/src/blueprints/datafile.py
+++ b/src/blueprints/datafile.py
@@ -57,8 +57,8 @@ class BaseDatafile(BaseModel, ABC):
     data_status: Optional[DataStatus] = None
 
     @property
-    def object_id(self) -> str:
-        """Main ID for a datafile"""
+    def display_name(self) -> str:
+        """Display name for a datafile (not necessarily unique)"""
         return self.filename
 
     @field_serializer("directory")

--- a/src/blueprints/dataset.py
+++ b/src/blueprints/dataset.py
@@ -18,7 +18,7 @@ class BaseDataset(BaseModel, ABC):
     validate against different standards, with the Dataset having a more strict
     validation than the RawDataset class."""
 
-    description: str
+    description: str = Field(min_length=1)
     data_classification: Optional[DataClassification] = None
     data_status: Optional[DataStatus] = None
     directory: Optional[Path] = None
@@ -26,6 +26,11 @@ class BaseDataset(BaseModel, ABC):
     groups: Optional[List[GroupACL]] = None
     immutable: bool = False
     identifiers: Optional[List[str]] = None
+
+    @property
+    def object_id(self) -> str:
+        """Main ID for a dataset"""
+        return self.description
 
 
 class RawDataset(BaseDataset):

--- a/src/blueprints/dataset.py
+++ b/src/blueprints/dataset.py
@@ -28,8 +28,8 @@ class BaseDataset(BaseModel, ABC):
     identifiers: Optional[List[str]] = None
 
     @property
-    def object_id(self) -> str:
-        """Main ID for a dataset"""
+    def display_name(self) -> str:
+        "Display name for a dataset"
         return self.description
 
 

--- a/src/blueprints/experiment.py
+++ b/src/blueprints/experiment.py
@@ -17,7 +17,7 @@ class BaseExperiment(BaseModel, ABC):
     validate against different standards, with the Experiment having a more strict
     validation than the RawExperiment class."""
 
-    title: str
+    title: str = Field(min_length=1)
     description: str
     data_classification: Optional[DataClassification] = None
     data_status: Optional[DataStatus] = None
@@ -27,6 +27,11 @@ class BaseExperiment(BaseModel, ABC):
     users: Optional[List[UserACL]] = None
     groups: Optional[List[GroupACL]] = None
     identifiers: Optional[List[str]] = None
+
+    @property
+    def object_id(self) -> str:
+        """Main ID for an experiment"""
+        return self.title
 
 
 class RawExperiment(BaseExperiment):

--- a/src/blueprints/experiment.py
+++ b/src/blueprints/experiment.py
@@ -29,8 +29,8 @@ class BaseExperiment(BaseModel, ABC):
     identifiers: Optional[List[str]] = None
 
     @property
-    def object_id(self) -> str:
-        """Main ID for an experiment"""
+    def display_name(self) -> str:
+        """Display name for an experiment"""
         return self.title
 
 

--- a/src/blueprints/project.py
+++ b/src/blueprints/project.py
@@ -17,7 +17,7 @@ class BaseProject(BaseModel, ABC):
     validate against different standards, with the Project having a more strict
     validation than the RawProject class."""
 
-    name: str
+    name: str = Field(min_length=1)
     description: str
     principal_investigator: Username
     data_classification: DataClassification = DataClassification.SENSITIVE
@@ -27,6 +27,11 @@ class BaseProject(BaseModel, ABC):
     users: Optional[List[UserACL]] = None
     groups: Optional[List[GroupACL]] = None
     identifiers: Optional[List[str]] = None
+
+    @property
+    def object_id(self) -> str:
+        """Main ID for a project"""
+        return self.name
 
 
 class RawProject(BaseProject):

--- a/src/blueprints/project.py
+++ b/src/blueprints/project.py
@@ -29,8 +29,8 @@ class BaseProject(BaseModel, ABC):
     identifiers: Optional[List[str]] = None
 
     @property
-    def object_id(self) -> str:
-        """Main ID for a project"""
+    def display_name(self) -> str:
+        """Display name for a project"""
         return self.name
 
 

--- a/src/forges/forge.py
+++ b/src/forges/forge.py
@@ -15,7 +15,7 @@ from src.blueprints.datafile import Datafile
 from src.blueprints.dataset import Dataset, DatasetParameterSet
 from src.blueprints.experiment import Experiment, ExperimentParameterSet
 from src.blueprints.project import Project, ProjectParameterSet
-from src.helpers.dataclass import get_object_name, get_object_post_type
+from src.helpers.dataclass import get_object_post_type
 from src.mytardis_client.mt_rest import BadGateWayException, MyTardisRESTFactory
 
 logger = logging.getLogger(__name__)
@@ -119,13 +119,15 @@ class Forge:
 
     def forge_object(  # pylint: disable=too-many-return-statements
         self,
-        refined_object: Project
-        | Experiment
-        | Dataset
-        | Datafile
-        | ProjectParameterSet
-        | ExperimentParameterSet
-        | DatasetParameterSet,
+        refined_object: (
+            Project
+            | Experiment
+            | Dataset
+            | Datafile
+            | ProjectParameterSet
+            | ExperimentParameterSet
+            | DatasetParameterSet
+        ),
         object_id: int | None = None,
         overwrite_objects: bool = False,
     ) -> URI | None:
@@ -193,7 +195,7 @@ class Forge:
                 if not uri:
                     message = (
                         "No URI was able to be discerned when creating object: "
-                        f"{get_object_name(refined_object)}. Object may have "
+                        f"{refined_object.object_id}. Object may have "
                         "been successfully created in MyTardis, but needs further "
                         "investigation."
                     )
@@ -202,7 +204,7 @@ class Forge:
 
                 logger.info(
                     (
-                        f"Object: {get_object_name(refined_object)} successfully "
+                        f"Object: {refined_object.object_id} successfully "
                         "created in MyTardis\n"
                         f"Url substring: {object_type['url_substring']}"
                     )

--- a/src/forges/forge.py
+++ b/src/forges/forge.py
@@ -195,7 +195,7 @@ class Forge:
                 if not uri:
                     message = (
                         "No URI was able to be discerned when creating object: "
-                        f"{refined_object.object_id}. Object may have "
+                        f"{refined_object.display_name}. Object may have "
                         "been successfully created in MyTardis, but needs further "
                         "investigation."
                     )
@@ -204,7 +204,7 @@ class Forge:
 
                 logger.info(
                     (
-                        f"Object: {refined_object.object_id} successfully "
+                        f"Object: {refined_object.display_name} successfully "
                         "created in MyTardis\n"
                         f"Url substring: {object_type['url_substring']}"
                     )

--- a/src/helpers/dataclass.py
+++ b/src/helpers/dataclass.py
@@ -30,21 +30,6 @@ from src.mytardis_client.enumerators import (
 )
 
 
-def get_object_name(
-    object_class: BaseDatafile | BaseDataset | BaseExperiment | BaseProject,
-) -> str:  # sourcery skip: assign-if-exp, reintroduce-else
-    """Generic helper function to get the name from a MyTardis  dataclass object"""
-    if isinstance(object_class, BaseDatafile):
-        return object_class.filename
-    if isinstance(object_class, BaseDataset):
-        return object_class.description
-    if isinstance(object_class, BaseExperiment):
-        return object_class.title
-    if isinstance(object_class, BaseProject):
-        return object_class.name
-    return ""
-
-
 def get_object_type(
     object_class: BaseDatafile | BaseDataset | BaseExperiment | BaseProject,
 ) -> ObjectDict | None:
@@ -61,14 +46,16 @@ def get_object_type(
 
 
 def get_object_parents(
-    object_class: RawDatafile
-    | RefinedDatafile
-    | RawDataset
-    | RefinedDataset
-    | RawExperiment
-    | RefinedExperiment
-    | RawProject
-    | RefinedProject,
+    object_class: (
+        RawDatafile
+        | RefinedDatafile
+        | RawDataset
+        | RefinedDataset
+        | RawExperiment
+        | RefinedExperiment
+        | RawProject
+        | RefinedProject
+    ),
 ) -> List[str] | None:  # sourcery skip: assign-if-exp, reintroduce-else
     """Function to get the parent objects from teh RawObject classes."""
     if isinstance(object_class, BaseDatafile):
@@ -83,13 +70,15 @@ def get_object_parents(
 
 
 def get_object_post_type(  # pylint: disable=too-many-return-statements
-    object_class: BaseDatafile
-    | BaseDataset
-    | BaseExperiment
-    | BaseProject
-    | ProjectParameterSet
-    | ExperimentParameterSet
-    | DatasetParameterSet,
+    object_class: (
+        BaseDatafile
+        | BaseDataset
+        | BaseExperiment
+        | BaseProject
+        | ProjectParameterSet
+        | ExperimentParameterSet
+        | DatasetParameterSet
+    ),
 ) -> ObjectPostDict:
     """Generic helper function to return the parameeters needed to correctly
     POST or PUT/PATCH a MyTardis object."""

--- a/src/ingestion_factory/factory.py
+++ b/src/ingestion_factory/factory.py
@@ -93,14 +93,14 @@ class IngestionFactory:
         for raw_project in projects:
             smelted_project = self.smelter.smelt_project(raw_project)
             if not smelted_project:
-                result.error.append(raw_project.object_id)
+                result.error.append(raw_project.display_name)
                 continue
 
             refined_project, refined_parameters = smelted_project
 
             project = self.crucible.prepare_project(refined_project)
             if not project:
-                result.error.append(refined_project.object_id)
+                result.error.append(refined_project.display_name)
                 continue
 
             matching_projects = self._overseer.get_objects(
@@ -114,11 +114,11 @@ class IngestionFactory:
                     project.name,
                     project_uri,
                 )
-                result.skipped.append((project.object_id, project_uri))
+                result.skipped.append((project.display_name, project_uri))
                 continue
 
             project_uri = self.forge.forge_project(project, refined_parameters)
-            result.success.append((project.object_id, project_uri))
+            result.success.append((project.display_name, project_uri))
 
         return result
 
@@ -133,14 +133,14 @@ class IngestionFactory:
         for raw_experiment in experiments:
             smelted_experiment = self.smelter.smelt_experiment(raw_experiment)
             if not smelted_experiment:
-                result.error.append(raw_experiment.object_id)
+                result.error.append(raw_experiment.display_name)
                 continue
 
             refined_experiment, refined_parameters = smelted_experiment
 
             experiment = self.crucible.prepare_experiment(refined_experiment)
             if not experiment:
-                result.error.append(refined_experiment.object_id)
+                result.error.append(refined_experiment.display_name)
                 continue
 
             matching_experiments = self._overseer.get_objects(
@@ -153,12 +153,12 @@ class IngestionFactory:
                     experiment.title,
                     experiment_uri,
                 )
-                result.skipped.append((experiment.object_id, experiment_uri))
+                result.skipped.append((experiment.display_name, experiment_uri))
                 continue
 
             experiment_uri = self.forge.forge_experiment(experiment, refined_parameters)
 
-            result.success.append((experiment.object_id, experiment_uri))
+            result.success.append((experiment.display_name, experiment_uri))
 
         return result
 
@@ -173,13 +173,13 @@ class IngestionFactory:
         for raw_dataset in datasets:
             smelted_dataset = self.smelter.smelt_dataset(raw_dataset)
             if not smelted_dataset:
-                result.error.append(raw_dataset.object_id)
+                result.error.append(raw_dataset.display_name)
                 continue
 
             refined_dataset, refined_parameters = smelted_dataset
             dataset = self.crucible.prepare_dataset(refined_dataset)
             if not dataset:
-                result.error.append(refined_dataset.object_id)
+                result.error.append(refined_dataset.display_name)
                 continue
 
             matching_datasets = self._overseer.get_objects(
@@ -192,11 +192,11 @@ class IngestionFactory:
                     dataset.description,
                     dataset_uri,
                 )
-                result.skipped.append((dataset.object_id, dataset_uri))
+                result.skipped.append((dataset.display_name, dataset_uri))
                 continue
 
             dataset_uri = self.forge.forge_dataset(dataset, refined_parameters)
-            result.success.append((dataset.object_id, dataset_uri))
+            result.success.append((dataset.display_name, dataset_uri))
 
         return result
 
@@ -211,12 +211,12 @@ class IngestionFactory:
         for raw_datafile in raw_datafiles:
             refined_datafile = self.smelter.smelt_datafile(raw_datafile)
             if not refined_datafile:
-                result.error.append(raw_datafile.object_id)
+                result.error.append(raw_datafile.display_name)
                 continue
 
             datafile = self.crucible.prepare_datafile(refined_datafile)
             if not datafile:
-                result.error.append(refined_datafile.object_id)
+                result.error.append(refined_datafile.display_name)
                 continue
             # Add a replica to represent the copy transferred by the Conveyor.
             datafile.replicas.append(self.conveyor.create_replica(datafile))
@@ -235,12 +235,12 @@ class IngestionFactory:
                     'Already ingested datafile "%s". Skipping datafile ingestion.',
                     datafile.directory,
                 )
-                result.skipped.append((datafile.object_id, None))
+                result.skipped.append((datafile.display_name, None))
                 continue
 
             self.forge.forge_datafile(datafile)
             datafiles.append(datafile)
-            result.success.append((datafile.object_id, None))
+            result.success.append((datafile.display_name, None))
 
         logger.info(
             "Successfully ingested %d datafile metadata: %s",

--- a/src/ingestion_factory/factory.py
+++ b/src/ingestion_factory/factory.py
@@ -18,7 +18,6 @@ from src.forges.forge import Forge
 from src.mytardis_client.mt_rest import MyTardisRESTFactory
 from src.overseers.overseer import Overseer
 from src.smelters.smelter import Smelter
-from src.utils.types.singleton import Singleton
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +37,7 @@ class IngestionResult:  # pylint: disable=missing-class-docstring
         return NotImplemented
 
 
-class IngestionFactory(metaclass=Singleton):
+class IngestionFactory:
     """Ingestion Factory base class to orchestrate the Smelting, and Forging of
     objects within MyTardis.
 

--- a/src/ingestion_factory/factory.py
+++ b/src/ingestion_factory/factory.py
@@ -303,21 +303,17 @@ class IngestionFactory:
         datasets: list[RawDataset],
         datafiles: list[RawDatafile],
     ) -> None:
-        if projects is not None:
-            ingested_projects = self.ingest_projects(projects)
-            self.log_results(ingested_projects, "project")
+        ingested_projects = self.ingest_projects(projects)
+        self.log_results(ingested_projects, "project")
 
-        if experiments is not None:
-            ingested_experiments = self.ingest_experiments(experiments)
-            self.log_results(ingested_experiments, "experiment")
+        ingested_experiments = self.ingest_experiments(experiments)
+        self.log_results(ingested_experiments, "experiment")
 
-        if datasets is not None:
-            ingested_datasets = self.ingest_datasets(datasets)
-            self.log_results(ingested_datasets, "dataset")
+        ingested_datasets = self.ingest_datasets(datasets)
+        self.log_results(ingested_datasets, "dataset")
 
-        if datafiles is not None:
-            ingested_datafiles = self.ingest_datafiles(datafiles)
-            self.log_results(ingested_datafiles, "datafile")
+        ingested_datafiles = self.ingest_datafiles(datafiles)
+        self.log_results(ingested_datafiles, "datafile")
 
         self.dump_ingestion_result_json(
             projects_result=ingested_projects,

--- a/src/ingestion_factory/factory.py
+++ b/src/ingestion_factory/factory.py
@@ -38,24 +38,17 @@ class IngestionResult:  # pylint: disable=missing-class-docstring
 
 
 class IngestionFactory:
-    """Ingestion Factory base class to orchestrate the Smelting, and Forging of
-    objects within MyTardis.
+    """Orchestrates the ingestion of raw metadata into MyTardis.
 
-    IngestionFactory is an abstract base class from which specific ingestion
-    factories should be subclassed. The Factory classes orchestrate the various
-    classes associated with ingestion in such a way that the Smelter, Overseer and Forge
-    classes are unaware of each other
+    The class runs the smelter-crucible-forge stages of the ingestion process, such that
+    the Smelter, Crucible and Forge classes are unaware of each other.
 
     Attributes:
-        self.overseer: An instance of the Overseer class
-        self.mytardis_setup: The return from the introspection API that specifies how MyTardis is
-            set up.
-        self.forge: An instance of the Forge class
-        self.smelter: An instance of a smelter class that varies for different ingestion approaches
-        self.glob_string: For smelters that use files, what is the extension or similar to search
-            for. See pathlib documentations for glob details.
-        self.default_institution: Either a name, or an identifier for an Institution to use as the
-            default for Project and Experiment creation.
+        mt_rest: client for interacting with MyTardis REST API
+        overseer: An instance of the Overseer class
+        smelter: used to refine the metadata for ingestion
+        crucible: used to prepare the metadata for ingestion
+        forge: used to upload the metadata to MyTardis
     """
 
     def __init__(
@@ -68,24 +61,7 @@ class IngestionFactory:
         crucible: Optional[Crucible] = None,
         conveyor: Optional[Conveyor] = None,
     ) -> None:
-        """Initialises the Factory with the configuration found in the config_dict.
-
-        Passes the config_dict to the overseer and forge instances to ensure that the
-        specific MyTardis configuration is shared across all classes
-
-        Args:
-            general : GeneralConfig
-                Pydantic config class containing general information
-            auth : AuthConfig
-                Pydantic config class containing information about authenticating with a MyTardis
-                instance
-            connection : ConnectionConfig
-                Pydantic config class containing information about connecting to a MyTardis instance
-            mytardis_setup : IntrospectionConfig
-                Pydantic config class containing information from the introspection API
-            smelter : Smelter
-                class instance of Smelter
-        """
+        """Initialises the IngestionFactory with the given configuration"""
 
         self.config = config
 

--- a/src/ingestion_factory/factory.py
+++ b/src/ingestion_factory/factory.py
@@ -226,6 +226,7 @@ class IngestionFactory:
                 ObjectSearchEnum.DATAFILE.value,
                 {
                     "filename": datafile.filename,
+                    "directory": datafile.directory.as_posix(),
                     "dataset": str(Overseer.resource_uri_to_id(datafile.dataset)),
                 },
             )

--- a/src/overseers/overseer.py
+++ b/src/overseers/overseer.py
@@ -202,6 +202,7 @@ class Overseer(metaclass=Singleton):
         object_type: ObjectSearchDict,
         field_values: dict[str, str],
     ) -> list[dict[str, Any]]:
+        """Retrieve objects from MyTardis with field values matching the ones in "field_values"."""
         response = self._get_object_from_mytardis(object_type, field_values)
         if response is None:
             raise HTTPError("MyTardis object query yielded no response")

--- a/src/overseers/overseer.py
+++ b/src/overseers/overseer.py
@@ -197,6 +197,18 @@ class Overseer(metaclass=Singleton):
                 new_list.append(obj)
         return new_list
 
+    def get_objects_by_fields(
+        self,
+        object_type: ObjectSearchDict,
+        field_values: dict[str, str],
+    ) -> list[dict[str, Any]]:
+        response = self._get_object_from_mytardis(object_type, field_values)
+        if response is None:
+            raise HTTPError("MyTardis object query yielded no response")
+        if objects := response.get("objects"):
+            return [objects]
+        return []
+
     def get_uris(
         self,
         object_type: ObjectSearchDict,


### PR DESCRIPTION
This makes changes to the `IngestionFactory` so that, before attempting to forge an object, we first check if MyTardis already has an object of that type with matching identifiers. If a match is found in MyTardis, we skip the forge step, and instead record the object as "skipped" in `IngestionResult`.

The goal of this is to enable incremental ingestion in some cases (e.g. if we have an existing project with existing datasets, and we want to add datasets to it, we don't want to try and forge the project again), or resumable ingestion (e.g. maybe the network connection drops during connection and we need to restart an ingestion mid-way).

A side change is to remove the `get_object_name()` function and replace it with an `object_id` property defined on each PEDD type, so the definition of the "name"/"id" is co-located with the dataclass definition. We also specify that the main ID can't be empty. Together these changes help remove some verbose error-checking in `IngestionFactory`.