### PR TITLE
Allow source data path in ingestion CLI to be a file

### DIFF
--- a/src/beneficiations/abstract_custom_beneficiation.py
+++ b/src/beneficiations/abstract_custom_beneficiation.py
@@ -29,11 +29,7 @@ class AbstractCustomBeneficiation(ABC):
         pass
 
     @abstractmethod
-    def beneficiate(
-        self,
-        beneficiation_data: Any,
-        ingestible_dclasses: IngestionManifest,
-    ) -> IngestionManifest:
+    def beneficiate(self, beneficiation_data: Any) -> IngestionManifest:
         """Parse metadata files of a given file type into raw dataclasses
 
         Args:

--- a/src/beneficiations/beneficiation.py
+++ b/src/beneficiations/beneficiation.py
@@ -33,11 +33,7 @@ class Beneficiation:
     ) -> None:
         self.beneficiation = beneficiation
 
-    def beneficiate(
-        self,
-        beneficiation_data: Dict[str, Any],
-        ingestible_dataclasses: IngestionManifest,
-    ) -> IngestionManifest:
+    def beneficiate(self, beneficiation_data: Dict[str, Any]) -> IngestionManifest:
         """Parse metadata files of a given file type into raw dataclasses
 
         Args:
@@ -50,8 +46,7 @@ class Beneficiation:
         logger.info("beneficiating")
 
         ing_dclasses_out = self.beneficiation.beneficiate(
-            beneficiation_data=beneficiation_data,
-            ingestible_dclasses=ingestible_dataclasses,
+            beneficiation_data=beneficiation_data
         )
 
         logger.info(f"ingestible projects = {ing_dclasses_out.get_projects()}")

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -258,4 +258,3 @@ class ConfigFromEnv(BaseSettings):
         env_file=".env", env_file_encoding="utf-8", env_nested_delimiter="__"
     )
     storage: FilesystemStorageBoxConfig
-    source_directory: Path

--- a/src/extraction/extraction_plant.py
+++ b/src/extraction/extraction_plant.py
@@ -74,7 +74,6 @@ class ExtractionPlant(IMetadataExtractor):
             Exception: If profile for extraction is not set.
         """
         out_man = OutputManager()
-        ing_dclasses = IngestionManifest()
 
         if self.prospector and self.prospector.custom_prospector:
             out_man = self._prospect(root_dir, out_man)
@@ -82,7 +81,7 @@ class ExtractionPlant(IMetadataExtractor):
         if self.miner and self.miner.custom_miner:
             out_man = self._mine(root_dir, out_man)
 
-        ingestible_dataclasses_out = self._beneficiate(root_dir, ing_dclasses)
+        ingestible_dataclasses_out = self._beneficiate(root_dir)
         return ingestible_dataclasses_out
 
     def _prospect(
@@ -120,13 +119,7 @@ class ExtractionPlant(IMetadataExtractor):
     #        return ingestible_dataclasses
 
     # Libby: changes to IDW _beneficiate - need to test with ABI-music
-    def _beneficiate(
-        self,
-        pth: Path,
-        ing_dclasses: IngestionManifest,
-    ) -> IngestionManifest:
+    def _beneficiate(self, pth: Path) -> IngestionManifest:
         logger.info("beneficiating")
-        ingestible_dataclasses = self.beneficiation.beneficiation.beneficiate(
-            pth, ing_dclasses
-        )
+        ingestible_dataclasses = self.beneficiation.beneficiation.beneficiate(pth)
         return ingestible_dataclasses

--- a/src/ingestion_biru.py
+++ b/src/ingestion_biru.py
@@ -74,7 +74,6 @@ class IDSIngestionScript:
         """
         self.yaml_path = Path(yaml_path)
         self.config = ConfigFromEnv(
-            source_directory=yaml_path,
             storage=FilesystemStorageBoxConfig(
                 storage_name=storage_name, target_root_dir=Path(storage_dir)
             ),

--- a/src/ingestion_biru.py
+++ b/src/ingestion_biru.py
@@ -154,7 +154,14 @@ class IDSIngestionScript:
         # Ingest the data object
         obj_name_attr = obj_type.lower()
         logger.info("Ingesting %s: %s", obj_type.lower(), obj_name_attr)
-        result = getattr(self.factory, f"ingest_{obj_type}s")([data_obj])
+
+        if isinstance(data_obj, RawDatafile):
+            result = self.factory.ingest_datafiles(
+                self.ingestible_dataclass.get_data_root(), [data_obj]
+            )
+        else:
+            # Ingest project, experiment, or dataset
+            result = getattr(self.factory, f"ingest_{obj_type}s")([data_obj])
 
         # Update the data status
         if result.success is not None:

--- a/src/ingestion_factory/factory.py
+++ b/src/ingestion_factory/factory.py
@@ -1,4 +1,3 @@
-# pylint: disable=R0801
 """A collection of classes for ingesting raw metadata into MyTardis."""
 import json
 import logging
@@ -92,7 +91,7 @@ class IngestionFactory:
     def ingest_projects(
         self,
         projects: list[RawProject],
-    ) -> IngestionResult:  # sourcery skip: class-extract-method
+    ) -> IngestionResult:
         """Ingest a set of projects into MyTardis."""
 
         result = IngestionResult()
@@ -129,7 +128,7 @@ class IngestionFactory:
 
         return result
 
-    def ingest_experiments(  # pylint: disable=too-many-locals
+    def ingest_experiments(
         self,
         experiments: list[RawExperiment],
     ) -> IngestionResult:
@@ -169,7 +168,7 @@ class IngestionFactory:
 
         return result
 
-    def ingest_datasets(  # pylint: disable=too-many-locals
+    def ingest_datasets(
         self,
         datasets: list[RawDataset],
     ) -> IngestionResult:

--- a/src/profiles/abi_music/parsing.py
+++ b/src/profiles/abi_music/parsing.py
@@ -251,7 +251,7 @@ def parse_raw_data(
     Parse the directory containing the raw data
     """
 
-    pedd_builder = IngestionManifest()
+    pedd_builder = IngestionManifest(source_data_root=root_dir)
 
     project_dirs = [
         d for d in raw_dir.iter_dirs(recursive=True) if d.has_file("project.json")
@@ -310,7 +310,7 @@ def parse_zarr_data(
     """
     Parse the directory containing the derived/post-processed Zarr data
     """
-    pedd_builder = IngestionManifest()
+    pedd_builder = IngestionManifest(source_data_root=root_dir)
 
     for directory in zarr_root.iter_dirs(recursive=True):
         zarr_dirs = directory.find_dirs(
@@ -375,6 +375,7 @@ def parse_data(root: DirectoryNode) -> IngestionManifest:
 
     # Note: maybe we should just directly append to the object inside the parsing functions
     return IngestionManifest(
+        source_data_root=root.path(),
         projects=dc_raw.get_projects() + dc_zarr.get_projects(),
         experiments=dc_raw.get_experiments() + dc_zarr.get_experiments(),
         datasets=dc_raw.get_datasets() + dc_zarr.get_datasets(),

--- a/src/profiles/idw/yaml_wrapper.py
+++ b/src/profiles/idw/yaml_wrapper.py
@@ -41,5 +41,5 @@ def write_to_yaml(fpath: Path, ingestible: IngestionManifest) -> None:
     for datafile in ingestible.get_datafiles():
         data_list.append(datafile)
 
-    with open(fpath / "ingestion.yaml", "w", encoding="utf-8") as f:
+    with open(fpath, "w", encoding="utf-8") as f:
         yaml.dump_all(data_list, f)

--- a/src/profiles/ro_crate/ro_crate_parser.py
+++ b/src/profiles/ro_crate/ro_crate_parser.py
@@ -478,5 +478,5 @@ class ROCrateExtractor(IMetadataExtractor):
 
     def extract(self, root_dir: Path) -> IngestionManifest:
         ro_crate_parser = ROCrateParser(root_dir)
-        empty_ingestibleclasses = IngestionManifest()
+        empty_ingestibleclasses = IngestionManifest(source_data_root=root_dir)
         return ro_crate_parser.parse_crate(empty_ingestibleclasses)

--- a/tests/test_biru_beneficiation.py
+++ b/tests/test_biru_beneficiation.py
@@ -1,18 +1,17 @@
 import logging
 from pathlib import Path
 
-from src.extraction.manifest import IngestionManifest
 from src.profiles.idw.custom_beneficiation import CustomBeneficiation
 
 logger = logging.getLogger(__name__)
 logger.propagate = True
 
 
-def test_beneficiate():
+def test_beneficiate() -> None:
     """Tests that beneficiation for BIRU is successful and extracts metadata."""
     a = CustomBeneficiation()
-    fpath = "tests/testdata/"
-    ingestible_dataclasses = a.beneficiate(Path(fpath), IngestionManifest())
+    fpath = "tests/testdata/ingestion.yaml"
+    ingestible_dataclasses = a.beneficiate(Path(fpath))
     df = ingestible_dataclasses.get_datafiles()[0]
     assert df.filename == "20221113_slide3-2_humanRWM_cd34_x20_0.12umpix_8.czi"
     assert df.metadata and df.metadata["Experimenter|UserName"] == "hsuz002"

--- a/tests/test_ingestion_manifest.py
+++ b/tests/test_ingestion_manifest.py
@@ -240,6 +240,7 @@ def _() -> IngestionManifest:
     ]
 
     manifest = IngestionManifest(
+        source_data_root=Path("/data/root/dir"),
         projects=raw_projects,
         experiments=raw_experiments,
         datasets=raw_datasets,
@@ -258,6 +259,12 @@ def test_serialize(ingestion_manifest: IngestionManifest, tmp_path: Path) -> Non
     output_dir.mkdir()
 
     ingestion_manifest.serialize(output_dir)
+
+    source_info_file = output_dir / "source.json"
+    assert source_info_file.is_file(), "Source info file should be created"
+
+    source_info = json.loads(source_info_file.read_text(encoding="utf-8"))
+    assert source_info["source_data_root"] == "/data/root/dir"
 
     projects_dir = DirectoryNode(output_dir / "projects")
     experiments_dir = DirectoryNode(output_dir / "experiments")
@@ -298,6 +305,7 @@ def test_serialize_deserialize_cycle(
 
     reloaded_manifest = IngestionManifest.deserialize(directory)
 
+    assert ingestion_manifest.get_data_root() == reloaded_manifest.get_data_root()
     assert ingestion_manifest.get_projects() == reloaded_manifest.get_projects()
     assert ingestion_manifest.get_experiments() == reloaded_manifest.get_experiments()
     assert ingestion_manifest.get_datasets() == reloaded_manifest.get_datasets()

--- a/tests/test_ro_crate_parser.py
+++ b/tests/test_ro_crate_parser.py
@@ -56,7 +56,8 @@ def test_read_crate_dataobjects(
     Also confirms that datasets haved been parsed correctly.
     """
     ingestible_dfs: IngestionManifest = fixture_rocrate_parser.process_datasets(
-        IngestionManifest(), filters.PathFilterSet(filter_system_files=True)
+        IngestionManifest(Path("/dummy/path")),
+        filters.PathFilterSet(filter_system_files=True),
     )
     assert len(ingestible_dfs.get_datasets()) == 2
     assert (
@@ -109,7 +110,7 @@ def test_parse_crate_project(
     fixture_rocrate_project: RawProject,
 ) -> None:
     ingestible_projects: IngestionManifest = fixture_rocrate_parser.process_projects(
-        IngestionManifest()
+        IngestionManifest(Path("/dummy/path"))
     )
     assert len(ingestible_projects.get_projects()) == 1
     testing_project = ingestible_projects.get_projects()[0]
@@ -126,7 +127,7 @@ def test_parse_crate_experiment(
     fixture_rocrate_experiment: RawExperiment,
 ) -> None:
     ingestible_projects: IngestionManifest = fixture_rocrate_parser.process_experiments(
-        IngestionManifest()
+        IngestionManifest(Path("/dummy/path"))
     )
     experiments = ingestible_projects.get_experiments()
     assert len(experiments) == 1


### PR DESCRIPTION
Currently the ingestion CLI accepts input of a path to a directory to indicate the source data to be ingested. This PR loosens this constraint, allowing the path to refer to a file as well, to support the BIRU profile/use-case where the ingestion is driven by a YAML file, not a directory. This may help with ingesting from archive files etc. in future.