### PR TITLE
IDS-600: fix bugs in ABI MuSIC ingestion profile

### DIFF
--- a/src/profiles/abi_music/parsing.py
+++ b/src/profiles/abi_music/parsing.py
@@ -144,10 +144,11 @@ def parse_raw_dataset(directory: DirectoryNode) -> tuple[RawDataset, str]:
         "sqrt-offset": json_data["Offsets"]["SQRT Offset"],
     }
 
-    main_id = "raw-" + json_data["Basename"]["Sequence"]
+    sequence_name = json_data["Basename"]["Sequence"]
+    main_id = sequence_name + "-raw"
 
     dataset = RawDataset(
-        description="Raw:" + directory.name(),
+        description=sequence_name + ":raw",
         data_classification=None,
         directory=None,
         users=None,
@@ -155,7 +156,7 @@ def parse_raw_dataset(directory: DirectoryNode) -> tuple[RawDataset, str]:
         immutable=False,
         identifiers=[
             main_id,
-            "raw-" + str(json_data["SequenceID"]),
+            str(json_data["SequenceID"]) + "-raw",
         ],
         experiments=[
             json_data["Basename"]["Sample"],
@@ -190,10 +191,12 @@ def parse_zarr_dataset(directory: DirectoryNode) -> tuple[RawDataset, str]:
         "sqrt-offset": json_data["config"]["Offsets"]["SQRT Offset"],
     }
 
-    main_id = "zarr-" + json_data["config"]["Basename"]["Sequence"]
+    sequence_name = json_data["config"]["Basename"]["Sequence"]
+
+    main_id = sequence_name + "-zarr"
 
     dataset = RawDataset(
-        description="Zarr:" + directory.name(),
+        description=sequence_name + ":zarr",
         data_classification=None,
         directory=None,
         users=None,
@@ -201,7 +204,7 @@ def parse_zarr_dataset(directory: DirectoryNode) -> tuple[RawDataset, str]:
         immutable=False,
         identifiers=[
             main_id,
-            "zarr-" + str(json_data["config"]["SequenceID"]),
+            str(json_data["config"]["SequenceID"]) + "-zarr",
         ],
         experiments=[
             json_data["config"]["Basename"]["Sample"],
@@ -350,7 +353,7 @@ def link_zarr_to_raw(
         raw_dataset = next(
             ds
             for ds in raw_datasets
-            if ds.description == zarr_dataset.description.replace("Zarr:", "Raw:")
+            if ds.description == zarr_dataset.description.replace(":zarr", ":raw")
         )
         zarr_dataset.metadata = zarr_dataset.metadata or {}
         zarr_dataset.metadata["raw_dataset"] = raw_dataset.description

--- a/src/profiles/abi_music/parsing.py
+++ b/src/profiles/abi_music/parsing.py
@@ -140,15 +140,14 @@ def parse_raw_dataset(directory: DirectoryNode) -> tuple[RawDataset, str]:
     json_data = read_json(directory.file(directory.name() + ".json"))
 
     metadata: dict[str, Any] = {
-        "description": json_data["Description"],
-        "sequence-id": json_data["SequenceID"],
+        "full-description": json_data["Description"],
         "sqrt-offset": json_data["Offsets"]["SQRT Offset"],
     }
 
     main_id = "raw-" + json_data["Basename"]["Sequence"]
 
     dataset = RawDataset(
-        description="Raw:" + json_data["Description"],
+        description="Raw:" + directory.name(),
         data_classification=None,
         directory=None,
         users=None,
@@ -187,15 +186,14 @@ def parse_zarr_dataset(directory: DirectoryNode) -> tuple[RawDataset, str]:
     json_data = read_json(json_file)
 
     metadata: dict[str, Any] = {
-        "description": json_data["config"]["Description"],
-        "sequence-id": json_data["config"]["SequenceID"],
+        "full-description": json_data["config"]["Description"],
         "sqrt-offset": json_data["config"]["Offsets"]["SQRT Offset"],
     }
 
     main_id = "zarr-" + json_data["config"]["Basename"]["Sequence"]
 
     dataset = RawDataset(
-        description="Zarr:" + json_data["config"]["Description"],
+        description="Zarr:" + directory.name(),
         data_classification=None,
         directory=None,
         users=None,

--- a/src/prospectors/common_file_checks.py
+++ b/src/prospectors/common_file_checks.py
@@ -11,7 +11,7 @@ from typing import Any, List, Tuple
 
 from src.profiles import profile_consts as pc
 from src.utils.filesystem.filters import (
-    get_excluded_system_extension_prefixes,
+    get_excluded_system_filename_prefixes,
     get_excluded_system_suffixes,
 )
 
@@ -31,7 +31,7 @@ class CommonDirectoryTreeChecks:
     ) -> None:
         """Instantiates look-up tables for common system files."""
         self.common_fnames_lut = dict.fromkeys(get_excluded_system_suffixes())
-        self.reject_prefix_lut = dict.fromkeys(get_excluded_system_extension_prefixes())
+        self.reject_prefix_lut = dict.fromkeys(get_excluded_system_filename_prefixes())
 
     def perform_common_file_checks(
         self,

--- a/src/utils/filesystem/filters.py
+++ b/src/utils/filesystem/filters.py
@@ -15,7 +15,7 @@ class FileExclusionPatterns:
     """
 
     suffixes: Optional[list[str]]
-    extension_prefixes: Optional[list[str]]
+    name_prefixes: Optional[list[str]]
 
 
 MACOS_EXCLUSION_PATTERNS = FileExclusionPatterns(
@@ -32,11 +32,11 @@ MACOS_EXCLUSION_PATTERNS = FileExclusionPatterns(
         ".FileSync-lock",
         ".AppleDB",
     ],
-    extension_prefixes=["._"],
+    name_prefixes=["._"],
 )
 
 WINDOWS_EXCLUSION_PATTERNS = FileExclusionPatterns(
-    suffixes=["thumbs.db"], extension_prefixes=None
+    suffixes=["thumbs.db"], name_prefixes=None
 )
 
 
@@ -50,13 +50,13 @@ def get_excluded_system_suffixes() -> list[str]:
     return suffixes
 
 
-def get_excluded_system_extension_prefixes() -> list[str]:
+def get_excluded_system_filename_prefixes() -> list[str]:
     """
     Get a list of common system file path suffixes
     """
     prefixes: list[str] = []
-    prefixes.extend(MACOS_EXCLUSION_PATTERNS.extension_prefixes or [])
-    prefixes.extend(WINDOWS_EXCLUSION_PATTERNS.extension_prefixes or [])
+    prefixes.extend(MACOS_EXCLUSION_PATTERNS.name_prefixes or [])
+    prefixes.extend(WINDOWS_EXCLUSION_PATTERNS.name_prefixes or [])
     return prefixes
 
 
@@ -95,7 +95,7 @@ class NameSuffixFilter(PathFilterBase):
         return any(path.name.endswith(suffix) for suffix in self._suffixes)
 
 
-class ExtensionPrefixFilter(PathFilterBase):
+class NamePrefixFilter(PathFilterBase):
     """
     Filter paths by matching their extensions against disallowed prefixes.
     """
@@ -105,7 +105,7 @@ class ExtensionPrefixFilter(PathFilterBase):
         super().__init__()
 
     def exclude(self, path: Path) -> bool:
-        return any(path.suffix.startswith(prefix) for prefix in self._prefixes)
+        return any(path.name.startswith(prefix) for prefix in self._prefixes)
 
 
 class PathPatternFilter(PathFilterBase):
@@ -121,8 +121,8 @@ class PathPatternFilter(PathFilterBase):
 
         if patterns.suffixes is not None:
             self._filters.append(NameSuffixFilter(patterns.suffixes))
-        if patterns.extension_prefixes is not None:
-            self._filters.append(ExtensionPrefixFilter(patterns.extension_prefixes))
+        if patterns.name_prefixes is not None:
+            self._filters.append(NamePrefixFilter(patterns.name_prefixes))
 
         super().__init__()
 

--- a/tests/test_utils_filesystem.py
+++ b/tests/test_utils_filesystem.py
@@ -2,8 +2,8 @@
 from pathlib import Path
 
 from src.utils.filesystem.filters import (
-    ExtensionPrefixFilter,
     FileExclusionPatterns,
+    NamePrefixFilter,
     NameSuffixFilter,
     PathFilterSet,
     PathPatternFilter,
@@ -23,26 +23,28 @@ def test_name_suffix_filter() -> None:
 
 
 def test_extension_prefix_filter() -> None:
-    filt = ExtensionPrefixFilter(["._", ".bad"])
+    filt = NamePrefixFilter(["._", ".bad"])
 
-    assert filt.exclude(Path("path/to/file._bad"))
-    assert filt.exclude(Path("path/to/file.badfile"))
+    assert filt.exclude(Path("path/to/._badfile.txt"))
+    assert filt.exclude(Path("path/to/._.txt"))
+    assert filt.exclude(Path("path/to/.badfile.txt"))
 
     assert not filt.exclude(Path("path/to/file._.bad.dots."))
-    assert not filt.exclude(Path("path/to/file._bad.double"))
-    assert not filt.exclude(Path("path/to/file.bad.double"))
+    assert not filt.exclude(Path("path/to/file._bad._double"))
+    assert not filt.exclude(Path("path/to/file.bad._double"))
 
 
 def test_path_pattern_filter() -> None:
-    patterns = FileExclusionPatterns(suffixes=[".bad"], extension_prefixes=["._"])
+    patterns = FileExclusionPatterns(suffixes=[".bad"], name_prefixes=["._"])
     filt = PathPatternFilter(patterns)
 
     assert filt.exclude(Path("file.bad"))
     assert filt.exclude(Path("path/to/file.bad"))
-    assert filt.exclude(Path("path/to/file._bad"))
+    assert filt.exclude(Path("path/to/._file.txt"))
 
     assert not filt.exclude(Path("path/to/file.badfile"))
     assert not filt.exclude(Path("path/to/file._.txt"))
+    assert not filt.exclude(Path("path/to/file._txt"))
 
 
 def test_file_system_filter_set() -> None:


### PR DESCRIPTION
Fix some bugs and issues in the behaviour of the ABI MuSIC ingestion profile:
- Incorrect filtering of MacOS "._" files (this is actually not specific to the profile but identified while reviewing an ingestion)
- TBC