### PR TITLE
Run static analysis before the tests in the PR checks

### DIFF
--- a/.github/workflows/mytardis_ingestion.yml
+++ b/.github/workflows/mytardis_ingestion.yml
@@ -37,6 +37,13 @@ jobs:
     - name: Black - check code formatting
       run: PYTHONPATH=src/ poetry run python -m black --check --diff src
 
+    - name: pylint - static code analysis
+      run: PYTHONPATH=src/ poetry run python -m pylint src/ --rcfile .pylintrc
+
+    - name: mypy - static type checking
+      # Takes configuration from pyproject.toml
+      run: PYTHONPATH=src/ poetry run python -m mypy
+
     - name: pytest - run the tests
       run: PYTHONPATH=src/ poetry run python -m pytest -v --cov=src/ tests/
 
@@ -50,10 +57,3 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-
-    - name: pylint - static code analysis
-      run: PYTHONPATH=src/ poetry run python -m pylint src/ --rcfile .pylintrc
-
-    - name: mypy - static type checking
-      # Takes configuration from pyproject.toml
-      run: PYTHONPATH=src/ poetry run python -m mypy


### PR DESCRIPTION
In the pipeline of PR checks, we have been running static analysis after running the tests, but the static analysis is much faster than the tests, so this PR makes the static analysis run first, to improve feedback/iteration time.

Conceptually it also seems to make sense to run the "static" steps first (i.e. ones that don't require code execution) before the dynamic ones, so we first catch any basic syntax/type errors.