### PR TITLE
Fix a bug in the filtering of Mac system files.

### DIFF
--- a/src/prospectors/common_file_checks.py
+++ b/src/prospectors/common_file_checks.py
@@ -11,7 +11,7 @@ from typing import Any, List, Tuple
 
 from src.profiles import profile_consts as pc
 from src.utils.filesystem.filters import (
-    get_excluded_system_extension_prefixes,
+    get_excluded_system_filename_prefixes,
     get_excluded_system_suffixes,
 )
 
@@ -31,7 +31,7 @@ class CommonDirectoryTreeChecks:
     ) -> None:
         """Instantiates look-up tables for common system files."""
         self.common_fnames_lut = dict.fromkeys(get_excluded_system_suffixes())
-        self.reject_prefix_lut = dict.fromkeys(get_excluded_system_extension_prefixes())
+        self.reject_prefix_lut = dict.fromkeys(get_excluded_system_filename_prefixes())
 
     def perform_common_file_checks(
         self,

--- a/src/utils/filesystem/filters.py
+++ b/src/utils/filesystem/filters.py
@@ -15,7 +15,7 @@ class FileExclusionPatterns:
     """
 
     suffixes: Optional[list[str]]
-    extension_prefixes: Optional[list[str]]
+    name_prefixes: Optional[list[str]]
 
 
 MACOS_EXCLUSION_PATTERNS = FileExclusionPatterns(
@@ -32,11 +32,11 @@ MACOS_EXCLUSION_PATTERNS = FileExclusionPatterns(
         ".FileSync-lock",
         ".AppleDB",
     ],
-    extension_prefixes=["._"],
+    name_prefixes=["._"],
 )
 
 WINDOWS_EXCLUSION_PATTERNS = FileExclusionPatterns(
-    suffixes=["thumbs.db"], extension_prefixes=None
+    suffixes=["thumbs.db"], name_prefixes=None
 )
 
 
@@ -50,13 +50,13 @@ def get_excluded_system_suffixes() -> list[str]:
     return suffixes
 
 
-def get_excluded_system_extension_prefixes() -> list[str]:
+def get_excluded_system_filename_prefixes() -> list[str]:
     """
     Get a list of common system file path suffixes
     """
     prefixes: list[str] = []
-    prefixes.extend(MACOS_EXCLUSION_PATTERNS.extension_prefixes or [])
-    prefixes.extend(WINDOWS_EXCLUSION_PATTERNS.extension_prefixes or [])
+    prefixes.extend(MACOS_EXCLUSION_PATTERNS.name_prefixes or [])
+    prefixes.extend(WINDOWS_EXCLUSION_PATTERNS.name_prefixes or [])
     return prefixes
 
 
@@ -95,7 +95,7 @@ class NameSuffixFilter(PathFilterBase):
         return any(path.name.endswith(suffix) for suffix in self._suffixes)
 
 
-class ExtensionPrefixFilter(PathFilterBase):
+class NamePrefixFilter(PathFilterBase):
     """
     Filter paths by matching their extensions against disallowed prefixes.
     """
@@ -105,7 +105,7 @@ class ExtensionPrefixFilter(PathFilterBase):
         super().__init__()
 
     def exclude(self, path: Path) -> bool:
-        return any(path.suffix.startswith(prefix) for prefix in self._prefixes)
+        return any(path.name.startswith(prefix) for prefix in self._prefixes)
 
 
 class PathPatternFilter(PathFilterBase):
@@ -121,8 +121,8 @@ class PathPatternFilter(PathFilterBase):
 
         if patterns.suffixes is not None:
             self._filters.append(NameSuffixFilter(patterns.suffixes))
-        if patterns.extension_prefixes is not None:
-            self._filters.append(ExtensionPrefixFilter(patterns.extension_prefixes))
+        if patterns.name_prefixes is not None:
+            self._filters.append(NamePrefixFilter(patterns.name_prefixes))
 
         super().__init__()
 

--- a/tests/test_utils_filesystem.py
+++ b/tests/test_utils_filesystem.py
@@ -2,8 +2,8 @@
 from pathlib import Path
 
 from src.utils.filesystem.filters import (
-    ExtensionPrefixFilter,
     FileExclusionPatterns,
+    NamePrefixFilter,
     NameSuffixFilter,
     PathFilterSet,
     PathPatternFilter,
@@ -23,26 +23,28 @@ def test_name_suffix_filter() -> None:
 
 
 def test_extension_prefix_filter() -> None:
-    filt = ExtensionPrefixFilter(["._", ".bad"])
+    filt = NamePrefixFilter(["._", ".bad"])
 
-    assert filt.exclude(Path("path/to/file._bad"))
-    assert filt.exclude(Path("path/to/file.badfile"))
+    assert filt.exclude(Path("path/to/._badfile.txt"))
+    assert filt.exclude(Path("path/to/._.txt"))
+    assert filt.exclude(Path("path/to/.badfile.txt"))
 
     assert not filt.exclude(Path("path/to/file._.bad.dots."))
-    assert not filt.exclude(Path("path/to/file._bad.double"))
-    assert not filt.exclude(Path("path/to/file.bad.double"))
+    assert not filt.exclude(Path("path/to/file._bad._double"))
+    assert not filt.exclude(Path("path/to/file.bad._double"))
 
 
 def test_path_pattern_filter() -> None:
-    patterns = FileExclusionPatterns(suffixes=[".bad"], extension_prefixes=["._"])
+    patterns = FileExclusionPatterns(suffixes=[".bad"], name_prefixes=["._"])
     filt = PathPatternFilter(patterns)
 
     assert filt.exclude(Path("file.bad"))
     assert filt.exclude(Path("path/to/file.bad"))
-    assert filt.exclude(Path("path/to/file._bad"))
+    assert filt.exclude(Path("path/to/._file.txt"))
 
     assert not filt.exclude(Path("path/to/file.badfile"))
     assert not filt.exclude(Path("path/to/file._.txt"))
+    assert not filt.exclude(Path("path/to/file._txt"))
 
 
 def test_file_system_filter_set() -> None:


### PR DESCRIPTION
We were looking for files whose extension starts with "._", but should be looking for files where the file name starts with "._", not the extension.