### PR TITLE
IDS-600-2-fix-abi-music-ingestion-issues

### DIFF
--- a/src/profiles/abi_music/parsing.py
+++ b/src/profiles/abi_music/parsing.py
@@ -257,9 +257,14 @@ def parse_raw_data(
 
     manifest = IngestionManifest(source_data_root=root.path())
 
-    project_dirs = [
-        d for d in root.iter_dirs(recursive=True) if d.has_file("project.json")
-    ]
+    project_dirs: list[DirectoryNode] = []
+
+    if root.has_file("project.json"):
+        project_dirs.append(root)
+
+    project_dirs.extend(
+        [d for d in root.iter_dirs(recursive=True) if d.has_file("project.json")]
+    )
 
     for project_dir in project_dirs:
         logging.info("Project directory: %s", project_dir.name())

--- a/src/profiles/abi_music/parsing.py
+++ b/src/profiles/abi_music/parsing.py
@@ -144,10 +144,11 @@ def parse_raw_dataset(directory: DirectoryNode) -> tuple[RawDataset, str]:
         "sqrt-offset": json_data["Offsets"]["SQRT Offset"],
     }
 
-    main_id = "raw-" + json_data["Basename"]["Sequence"]
+    sequence_name = json_data["Basename"]["Sequence"]
+    main_id = sequence_name + "-raw"
 
     dataset = RawDataset(
-        description="Raw:" + directory.name(),
+        description=sequence_name + ":raw",
         data_classification=None,
         directory=None,
         users=None,
@@ -155,7 +156,7 @@ def parse_raw_dataset(directory: DirectoryNode) -> tuple[RawDataset, str]:
         immutable=False,
         identifiers=[
             main_id,
-            "raw-" + str(json_data["SequenceID"]),
+            str(json_data["SequenceID"]) + "-raw",
         ],
         experiments=[
             json_data["Basename"]["Sample"],
@@ -190,10 +191,12 @@ def parse_zarr_dataset(directory: DirectoryNode) -> tuple[RawDataset, str]:
         "sqrt-offset": json_data["config"]["Offsets"]["SQRT Offset"],
     }
 
-    main_id = "zarr-" + json_data["config"]["Basename"]["Sequence"]
+    sequence_name = json_data["config"]["Basename"]["Sequence"]
+
+    main_id = sequence_name + "-zarr"
 
     dataset = RawDataset(
-        description="Zarr:" + directory.name(),
+        description=sequence_name + ":zarr",
         data_classification=None,
         directory=None,
         users=None,
@@ -201,7 +204,7 @@ def parse_zarr_dataset(directory: DirectoryNode) -> tuple[RawDataset, str]:
         immutable=False,
         identifiers=[
             main_id,
-            "zarr-" + str(json_data["config"]["SequenceID"]),
+            str(json_data["config"]["SequenceID"]) + "-zarr",
         ],
         experiments=[
             json_data["config"]["Basename"]["Sample"],
@@ -350,7 +353,7 @@ def link_zarr_to_raw(
         raw_dataset = next(
             ds
             for ds in raw_datasets
-            if ds.description == zarr_dataset.description.replace("Zarr:", "Raw:")
+            if ds.description == zarr_dataset.description.replace(":zarr", ":raw")
         )
         zarr_dataset.metadata = zarr_dataset.metadata or {}
         zarr_dataset.metadata["raw_dataset"] = raw_dataset.description

--- a/src/profiles/abi_music/parsing.py
+++ b/src/profiles/abi_music/parsing.py
@@ -108,6 +108,9 @@ def parse_experiment_info(directory: DirectoryNode) -> RawExperiment:
 
     json_data = read_json(directory.file("experiment.json"))
 
+    # The data features both "project" and "projects" keys, so we need to handle both
+    projects: list[str] = json_data.get("projects") or [json_data["project"]]
+
     raw_experiment = RawExperiment(
         title=json_data["experiment_name"],
         description=json_data["experiment_description"],
@@ -118,7 +121,7 @@ def parse_experiment_info(directory: DirectoryNode) -> RawExperiment:
         users=None,
         groups=None,
         identifiers=json_data["experiment_ids"],
-        projects=[json_data["project"]],
+        projects=projects,
         institution_name=None,
         metadata=None,
         schema=None,

--- a/src/profiles/abi_music/parsing.py
+++ b/src/profiles/abi_music/parsing.py
@@ -140,15 +140,14 @@ def parse_raw_dataset(directory: DirectoryNode) -> tuple[RawDataset, str]:
     json_data = read_json(directory.file(directory.name() + ".json"))
 
     metadata: dict[str, Any] = {
-        "description": json_data["Description"],
-        "sequence-id": json_data["SequenceID"],
+        "full-description": json_data["Description"],
         "sqrt-offset": json_data["Offsets"]["SQRT Offset"],
     }
 
     main_id = "raw-" + json_data["Basename"]["Sequence"]
 
     dataset = RawDataset(
-        description="Raw:" + json_data["Description"],
+        description="Raw:" + directory.name(),
         data_classification=None,
         directory=None,
         users=None,
@@ -187,15 +186,14 @@ def parse_zarr_dataset(directory: DirectoryNode) -> tuple[RawDataset, str]:
     json_data = read_json(json_file)
 
     metadata: dict[str, Any] = {
-        "description": json_data["config"]["Description"],
-        "sequence-id": json_data["config"]["SequenceID"],
+        "full-description": json_data["config"]["Description"],
         "sqrt-offset": json_data["config"]["Offsets"]["SQRT Offset"],
     }
 
     main_id = "zarr-" + json_data["config"]["Basename"]["Sequence"]
 
     dataset = RawDataset(
-        description="Zarr:" + json_data["config"]["Description"],
+        description="Zarr:" + directory.name(),
         data_classification=None,
         directory=None,
         users=None,


### PR DESCRIPTION
In the ABI MuSIC ingestion profile, remove assumptions about a specific directory structure (e.g. having "Vault", "Raw" and "Zarr" directories in the root), to deal with a different data layout in the "real" research drive (the previous code was developed against a "test" research drive with some sample data).

Also change the "raw" and "zarr" dataset name qualifiers from prefixes to suffixes, so the names sort better