### PR TITLE
Fix URI lookups in the crucible

### DIFF
--- a/src/crucible/crucible.py
+++ b/src/crucible/crucible.py
@@ -28,8 +28,8 @@ class Crucible:
         MyTardis and finding their URIs"""
         institutions: list[URI] = []
         for institution in refined_project.institution:
-            if institution_uri := self.overseer.get_uris_by_identifier(
-                MyTardisObject.INSTITUTION, institution
+            if institution_uri := self.overseer.get_uris(
+                MyTardisObject.INSTITUTION, {"name": institution}
             ):
                 institutions.append(*institution_uri)
         institutions = list(set(institutions))
@@ -142,8 +142,8 @@ class Crucible:
         if not experiment_uris:
             logger.warning("Unable to find experiments associated with this dataset.")
             return None
-        instruments = self.overseer.get_uris_by_identifier(
-            MyTardisObject.INSTRUMENT, refined_dataset.instrument
+        instruments = self.overseer.get_uris(
+            MyTardisObject.INSTRUMENT, {"name": refined_dataset.instrument}
         )
         if instruments:
             instruments = list(set(instruments))


### PR DESCRIPTION
In the Crucible, there are stages where we look up URIs for the institution associated with a project, and the instrument associated with a dataset. In a recent code change, we made these perform lookup by identifier, but these object types may not always have identifiers defined, and so the changes here ensure we search by the "name" field (we assume this is sufficiently unique for these object types, which is reasonable at the moment).