### PR TITLE
Query institution and instrument by identifier in the Crucible

### DIFF
--- a/src/crucible/crucible.py
+++ b/src/crucible/crucible.py
@@ -28,8 +28,8 @@ class Crucible:
         MyTardis and finding their URIs"""
         institutions: list[URI] = []
         for institution in refined_project.institution:
-            if institution_uri := self.overseer.get_uris(
-                MyTardisObject.INSTITUTION, {"name": institution}
+            if institution_uri := self.overseer.get_uris_by_identifier(
+                MyTardisObject.INSTITUTION, institution
             ):
                 institutions.append(*institution_uri)
         institutions = list(set(institutions))
@@ -142,8 +142,8 @@ class Crucible:
         if not experiment_uris:
             logger.warning("Unable to find experiments associated with this dataset.")
             return None
-        instruments = self.overseer.get_uris(
-            MyTardisObject.INSTRUMENT, {"name": refined_dataset.instrument}
+        instruments = self.overseer.get_uris_by_identifier(
+            MyTardisObject.INSTRUMENT, refined_dataset.instrument
         )
         if instruments:
             instruments = list(set(instruments))

--- a/src/profiles/abi_music/abi_music_consts.py
+++ b/src/profiles/abi_music/abi_music_consts.py
@@ -1,8 +1,6 @@
 """Add profile-specific constants in this module
 """
 
-DEFAULT_INSTITUTION = "University of Auckland"
-
 ABI_MUSIC_MICROSCOPE_INSTRUMENT = "abi-music-microscope-v1"
 ABI_MUSIC_POSTPROCESSING_INSTRUMENT = "abi-music-post-processing-v1"
 

--- a/src/profiles/abi_music/parsing.py
+++ b/src/profiles/abi_music/parsing.py
@@ -26,7 +26,6 @@ from src.profiles.abi_music.abi_music_consts import (
     ABI_MUSIC_DATASET_ZARR_SCHEMA,
     ABI_MUSIC_MICROSCOPE_INSTRUMENT,
     ABI_MUSIC_POSTPROCESSING_INSTRUMENT,
-    DEFAULT_INSTITUTION,
 )
 from src.utils.filesystem import checksums, filters
 from src.utils.filesystem.filesystem_nodes import DirectoryNode, FileNode
@@ -95,7 +94,7 @@ def parse_project_info(directory: DirectoryNode) -> RawProject:
         users=users or None,
         groups=groups or None,
         identifiers=json_data["project_ids"],
-        institution=[DEFAULT_INSTITUTION],
+        institution=None,
         metadata=None,
         schema=None,
         start_time=None,


### PR DESCRIPTION
Change our use of `Overseer` within the `Crucible`, so when we query MyTardis for institutions and instruments, we do so by identifier, and not by name. Historically it has been ambigious what we have been using (name or identifier), but it's likely we have been effectively relying on the strings defining thse being treated as identifiers.

The recent changes in https://github.com/UoA-eResearch/mytardis_ingestion/pull/418 changed the crucible to query by name, but we now think this is error-prone, so we're effectively reverting that change here.

The other small change is to get the ABI MuSIC profile to avoid defining its own default institution.