### PR TITLE
Add timestamps to the log message prefix

### DIFF
--- a/src/utils/log_utils.py
+++ b/src/utils/log_utils.py
@@ -15,13 +15,15 @@ def init_logging(file_name: Optional[str] = None, level: int = logging.DEBUG) ->
     root = logging.getLogger()
     root.setLevel(level)
 
+    log_format = "[%(asctime)s %(levelname)s]: %(message)s"
+
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(level)
-    console_handler.setFormatter(logging.Formatter("[%(levelname)s]: %(message)s"))
+    console_handler.setFormatter(logging.Formatter(log_format))
     root.addHandler(console_handler)
 
     if file_name:
         file_handler = logging.FileHandler(filename=file_name, mode="w")
         file_handler.setLevel(level)
-        file_handler.setFormatter(logging.Formatter("[%(levelname)s]: %(message)s"))
+        file_handler.setFormatter(logging.Formatter(log_format))
         root.addHandler(file_handler)


### PR DESCRIPTION
Add timestamps into the log message prefix, to get more context when reading logs. 

Example of the new output:
![image](https://github.com/UoA-eResearch/mytardis_ingestion/assets/142769327/8f5c9326-12cf-46d4-88ea-2f786baf03d9)
