### PR TITLE
Fix incorrect datafile directory in the ABI MuSIC profile

### DIFF
--- a/src/profiles/abi_music/parsing.py
+++ b/src/profiles/abi_music/parsing.py
@@ -260,8 +260,8 @@ def collate_datafile_info(
         mimetype = "application/octet-stream"
 
     return RawDatafile(
-        filename=file_rel_path.name,
-        directory=file_rel_path,
+        filename=file.name(),
+        directory=file_rel_path.parent,
         md5sum=checksums.calculate_md5(file.path()),
         mimetype=mimetype,
         size=file.stat().st_size,


### PR DESCRIPTION
Fix a bug in the ABI MuSIC profile - we were populating the datafile directory field with the relative file path, whereas it should be the relative parent directory path.