### PR TITLE
Simplify extracting ID from URI for GET request

### DIFF
--- a/src/ingestion_factory/factory.py
+++ b/src/ingestion_factory/factory.py
@@ -16,7 +16,7 @@ from src.conveyor.conveyor import Conveyor, FailedTransferException
 from src.crucible.crucible import Crucible
 from src.extraction.manifest import IngestionManifest
 from src.forges.forge import Forge
-from src.mytardis_client.data_types import CONTEXT_USE_URI_ID_ONLY, URI
+from src.mytardis_client.data_types import URI
 from src.mytardis_client.mt_rest import MyTardisRESTFactory
 from src.mytardis_client.objects import MyTardisObject
 from src.overseers.overseer import Overseer
@@ -181,8 +181,7 @@ class IngestionFactory:
                 continue
 
             matching_datasets = self._overseer.get_matching_objects(
-                MyTardisObject.DATASET,
-                dataset.model_dump(context=CONTEXT_USE_URI_ID_ONLY),
+                MyTardisObject.DATASET, dataset.model_dump()
             )
             if len(matching_datasets) > 0:
                 dataset_uri = URI(matching_datasets[0]["resource_uri"])
@@ -223,7 +222,7 @@ class IngestionFactory:
 
             matching_datafiles = self._overseer.get_matching_objects(
                 MyTardisObject.DATAFILE,
-                datafile.model_dump(context=CONTEXT_USE_URI_ID_ONLY),
+                datafile.model_dump(),
             )
             if len(matching_datafiles) > 0:
                 logging.info(

--- a/src/mytardis_client/data_types.py
+++ b/src/mytardis_client/data_types.py
@@ -7,7 +7,7 @@ import re
 from typing import Any, Literal
 from urllib.parse import urlparse
 
-from pydantic import RootModel, SerializationInfo, field_serializer, field_validator
+from pydantic import RootModel, field_serializer, field_validator
 
 from src.mytardis_client.objects import KNOWN_MYTARDIS_OBJECTS
 
@@ -47,17 +47,8 @@ def resource_uri_to_id(uri: str) -> int:
     return int(urlparse(uri).path.rstrip(uri_sep).split(uri_sep).pop())
 
 
-_KEY_USE_ID_ONLY_FROM_URI = "use_only_id_from_uri"
-CONTEXT_USE_URI_ID_ONLY = {_KEY_USE_ID_ONLY_FROM_URI: True}
-
-
 class URI(RootModel[str], frozen=True):
-    """A MyTardis URI string, with validation and serialization logic.
-
-    Note that the serialization method may either write the full URI, or just the ID
-    component, depending on the context passed in. See the serialize_uri method docs
-    for details.
-    """
+    """A MyTardis URI string, with validation and serialization logic."""
 
     root: str
 
@@ -76,18 +67,7 @@ class URI(RootModel[str], frozen=True):
         return validate_uri(value)
 
     @field_serializer("root")
-    def serialize_uri(self, uri: str, info: SerializationInfo) -> str:
-        """Serialize a URI, optionally extracting just the ID component, as MyTardis
-        requires this sometimes (e.g. for GET requests), but we only know this at
-        serialization time.
-
-        The context can be passed to a Pydantic model containing URI fields, and it will be
-        propagated down into all URI fields, so the serialization can be controlled in
-        one place. Ideally the MyTardis client would encapsulate this logic eventually.
-        """
-
-        if context := info.context:
-            if context.get(_KEY_USE_ID_ONLY_FROM_URI):
-                return str(resource_uri_to_id(uri))
+    def serialize_uri(self, uri: str) -> str:
+        """Serialize the URI as a simple string"""
 
         return uri

--- a/tests/test_mytardis_client_data_types.py
+++ b/tests/test_mytardis_client_data_types.py
@@ -2,11 +2,7 @@
 # nosec assert_used
 import pytest
 
-from src.mytardis_client.data_types import (
-    CONTEXT_USE_URI_ID_ONLY,
-    URI,
-    resource_uri_to_id,
-)
+from src.mytardis_client.data_types import URI, resource_uri_to_id
 from src.mytardis_client.objects import KNOWN_MYTARDIS_OBJECTS
 
 
@@ -64,4 +60,3 @@ def test_uri_serialization() -> None:
     uri = URI(uri_content)
 
     assert uri.model_dump() == uri_content
-    assert uri.model_dump(context=CONTEXT_USE_URI_ID_ONLY) == "10"


### PR DESCRIPTION
Change where we extract IDs from URIs for GET request parameters.

Background: when submitting GET requests to MyTardis, URI-based references to MyTardis resources need to be converted to bare IDs (MyTardis rejects full URIs in this context). Recently a flag was added to the serialization of the URI dataclass, to allow it to be serialized as just the ID component. The idea was that consumers of the client would need to pass this flag to calls to pydantic's `model_dump()` when serializing dataclasses containing URIs, if the data was going to be used in a GET request.

This previous approach has been found to be error-prone, and is arguably a leaky abstraction, as consumers of the Overseer need to know to do this, due to a low-level detail of the MyTardis API.

With this change, we instead do the extraction of IDs from URIs inside the `request` method of the MyTardis client, so it's automatically applied for GET requests, and only GET requests, meaning consumers don't need to do anything special to get the necessary behaviour.