### PR TITLE
Support sanitizing of nested query parameters

### DIFF
--- a/src/mytardis_client/mt_rest.py
+++ b/src/mytardis_client/mt_rest.py
@@ -6,7 +6,7 @@ is heavily based on the NGS ingestor for MyTardis found at
 """
 
 from copy import deepcopy
-from typing import Any, Dict, Generic, Literal, Optional, TypeVar
+from typing import Any, Callable, Dict, Generic, Literal, Optional, TypeVar
 from urllib.parse import urljoin
 
 import backoff
@@ -95,18 +95,23 @@ def sanitize_params(params: dict[str, Any]) -> dict[str, Any]:
         A dictionary of parameters with sanitised values.
     """
 
-    for key, value in params.items():
-        if isinstance(value, (dict, list)):
-            raise ValueError(
-                f"Nested query parameters not currently supported. Params are: {params}"
-            )
-
     updated_params = deepcopy(params)
 
-    # Replace any URIs with the ID as this is what MyTardis requires for GET requests
-    for key, value in updated_params.items():
+    def visit_entries(obj: Any, update: Callable[[Any], Any]) -> Any:
+
+        if isinstance(obj, dict):
+            return {k: visit_entries(v, update) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [visit_entries(v, update) for v in obj]
+        return update(obj)
+
+    def replace_uri_with_id(value: Any) -> Any:
         if isinstance(value, URI):
-            updated_params[key] = value.id
+            return value.id
+        return value
+
+    # Replace any URIs with the ID as this is what MyTardis requires for GET requests
+    updated_params = visit_entries(updated_params, replace_uri_with_id)
 
     return updated_params
 

--- a/src/mytardis_client/mt_rest.py
+++ b/src/mytardis_client/mt_rest.py
@@ -11,7 +11,7 @@ from urllib.parse import urljoin
 
 import backoff
 import requests
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from requests import Response
 from requests.exceptions import RequestException
 
@@ -108,6 +108,12 @@ def sanitize_params(params: dict[str, Any]) -> dict[str, Any]:
     def replace_uri_with_id(value: Any) -> Any:
         if isinstance(value, URI):
             return value.id
+        if isinstance(value, str):
+            try:
+                return URI(value).id
+            except ValidationError:
+                pass
+
         return value
 
     # Replace any URIs with the ID as this is what MyTardis requires for GET requests

--- a/tests/test_mytardis_client_rest_factory.py
+++ b/tests/test_mytardis_client_rest_factory.py
@@ -187,20 +187,84 @@ def test_mytardis_client_rest_get_all(
     assert total_count == 30
 
 
-def test_mytardis_client_sanitize_params() -> None:
+@pytest.mark.parametrize(
+    "input_params,expected_sanitized",
+    [
+        pytest.param(
+            {"string": "Hello", "int": 12, "dataset": URI("/api/v1/dataset/34/")},
+            {"string": "Hello", "int": 12, "dataset": 34},
+            id="no-nesting",
+        ),
+        pytest.param(
+            {
+                "string": "Hello",
+                "nested_dict": {"string": "Foo", "dataset": URI("/api/v1/dataset/34/")},
+            },
+            {
+                "string": "Hello",
+                "nested_dict": {"string": "Foo", "dataset": 34},
+            },
+            id="nested-dict",
+        ),
+        pytest.param(
+            {
+                "string": "Foo",
+                "nested_list": [URI("/api/v1/dataset/10/"), URI("/api/v1/dataset/11/")],
+            },
+            {
+                "string": "Foo",
+                "nested_list": [10, 11],
+            },
+            id="nested-list",
+        ),
+        pytest.param(
+            {
+                "string": "Foo",
+                "nested_list": [URI("/api/v1/dataset/10/"), URI("/api/v1/dataset/11/")],
+                "nested_dict": {"string": "Foo", "dataset": URI("/api/v1/dataset/34/")},
+            },
+            {
+                "string": "Foo",
+                "nested_list": [10, 11],
+                "nested_dict": {"string": "Foo", "dataset": 34},
+            },
+            id="nested-list-and-dict",
+        ),
+        pytest.param(
+            {
+                "string": "Foo",
+                "nested_list_of_dicts": [
+                    {"string": "Foo", "dataset": URI("/api/v1/dataset/34/")},
+                    {"string": "Bar", "dataset": URI("/api/v1/dataset/35/")},
+                ],
+                "nested_dict_with_list": {
+                    "string": "Foo",
+                    "datasets": [
+                        URI("/api/v1/dataset/34/"),
+                        URI("/api/v1/dataset/35/"),
+                    ],
+                },
+            },
+            {
+                "string": "Foo",
+                "nested_list_of_dicts": [
+                    {"string": "Foo", "dataset": 34},
+                    {"string": "Bar", "dataset": 35},
+                ],
+                "nested_dict_with_list": {
+                    "string": "Foo",
+                    "datasets": [34, 35],
+                },
+            },
+            id="doubly-nested",
+        ),
+    ],
+)
+def test_mytardis_client_sanitize_params(
+    input_params: dict[str, Any], expected_sanitized: dict[str, Any]
+) -> None:
 
-    sanitized = sanitize_params(
-        {
-            "string": "Hello",
-            "int": 12,
-            "uri": URI("/api/v1/dataset/34/"),
-        }
-    )
-    assert sanitized == {
-        "string": "Hello",
-        "int": 12,
-        "uri": 34,
-    }
+    assert sanitize_params(input_params) == expected_sanitized
 
 
 @responses.activate

--- a/tests/test_mytardis_client_rest_factory.py
+++ b/tests/test_mytardis_client_rest_factory.py
@@ -258,6 +258,17 @@ def test_mytardis_client_rest_get_all(
             },
             id="doubly-nested",
         ),
+        pytest.param(
+            {
+                "uri_string": "/api/v1/dataset/34/",
+                "uri_strings": ["/api/v1/dataset/34/", "/api/v1/dataset/35/"],
+            },
+            {
+                "uri_string": 34,
+                "uri_strings": [34, 35],
+            },
+            id="uris-stored-as-strings",
+        ),
     ],
 )
 def test_mytardis_client_sanitize_params(


### PR DESCRIPTION
When submitting GET requests to MyTardis, one quirk is that in the query parameters, references to resources need to be integer IDs, not the URIs which are often returned by MyTardis.

To handle this, we make a call to `sanitize_params()` to replace any URIs with their corresponding ID component. This method was initially written to support only flat `dict`s of parameters, but it turns out we need to support nested parameters (e.g. we may want to query for datasets using a list of experiments as query parameters).

The changes here are to support this nesting.