### PR TITLE
Delete unused test fixtures

### DIFF
--- a/src/blueprints/datafile.py
+++ b/src/blueprints/datafile.py
@@ -42,10 +42,7 @@ class BaseDatafile(BaseModel, ABC):
             the MIME type of the file to be ingested
         size: int
             the size in bytes of the file to be ingested
-        archive_date: ISODateTime
-            the date that the datafile will be automatically archived
-        delete_date: ISODateTime
-            the date that the datafile is able to be deleted"""
+    """
 
     filename: str = Field(min_length=1)
     directory: Optional[Path] = None

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -177,8 +177,6 @@ class ConfigFromEnv(BaseSettings):
             instance of Pydantic storage model
         default_schema : SchemaConfig
             instance of Pydantic schema model
-        archive: TimeOffsetConfig
-            instance of Pydantic time offset model
 
     ## Usage
     Requires a .env file in the current working direction:
@@ -198,7 +196,6 @@ class ConfigFromEnv(BaseSettings):
     # DEFAULT_SCHEMA__EXPERIMENT=
     # DEFAULT_SCHEMA__DATASET=
     # DEFAULT_SCHEMA__DATAFILE=
-    # Archive, prefix with ARCHIVE__
 
     '''
     ## Example

--- a/src/smelters/smelter.py
+++ b/src/smelters/smelter.py
@@ -265,10 +265,6 @@ class Smelter:
                 groups=raw_datafile.groups,
                 dataset=raw_datafile.dataset,
                 parameter_sets=[parameters] if parameters is not None else None,
-                # archive_date=raw_datafile.archive_date,
-                # delete_date=raw_datafile.delete_date,
-                # archive_offset=raw_datafile.archive_offset,
-                # delete_offset=raw_datafile.delete_offset,
             )
         except ValidationError:
             logger.warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,22 +106,9 @@ institution_address = const.institution_address
 institution_ids = const.institution_ids
 institution_country = const.institution_country
 institution_name = const.institution_name
-datafile_archive_date = const.datafile_archive_date
-datafile_delete_date = const.datafile_delete_date
 storage_class = const.storage_class
 storage_options = const.storage_options
 storage_attributes = const.storage_attributes
-archive_class = const.archive_class
-archive_options = const.archive_options
-archive_attributes = const.archive_attributes
-autoarchive_offset = const.autoarchive_offset
-delete_offset = const.delete_offset
-archive_box_name = const.archive_box_name
-archive_box_uri = const.archive_box_uri
-archive_box_description = const.archive_box_description
-archive_box_dir = const.archive_box_dir
-archive_date = const.archive_date
-delete_date = const.delete_date
 datetime_now = const.datetime_now
 
 # =============================
@@ -559,15 +546,11 @@ general = cfg.general
 auth = cfg.auth
 connection = cfg.connection
 active_store = cfg.active_store
-archive_store = cfg.archive_store
 default_schema = cfg.default_schema
 mytardis_settings = cfg.mytardis_settings
 storage_box_name = cfg.storage_box_name
 storage_attributes = cfg.storage_attributes
 storage_class = cfg.storage_class
-archive_box_name = cfg.archive_box_name
-archive_attributes = cfg.archive_attributes
-archive_class = cfg.archive_class
 
 # =========================================
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -545,7 +545,6 @@ get_project_details = rsps.get_project_details
 general = cfg.general
 auth = cfg.auth
 connection = cfg.connection
-active_store = cfg.active_store
 default_schema = cfg.default_schema
 mytardis_settings = cfg.mytardis_settings
 storage_box_name = cfg.storage_box_name

--- a/tests/fixtures/fixtures_config_from_env.py
+++ b/tests/fixtures/fixtures_config_from_env.py
@@ -13,7 +13,6 @@ from src.config.config import (
     GeneralConfig,
     ProxyConfig,
     SchemaConfig,
-    StorageBoxConfig,
 )
 
 
@@ -51,21 +50,6 @@ def storage_attributes() -> Dict[str, str]:
 
 
 @fixture
-def active_store(
-    storage_box_name: str,
-    storage_class: StorageTypesEnum,
-    storage_options: Dict[str, str],
-    storage_attributes: Dict[str, str],
-) -> StorageBoxConfig:
-    return StorageBoxConfig(
-        storage_name=storage_box_name,
-        storage_class=storage_class,
-        options=storage_options,
-        attributes=storage_attributes,
-    )
-
-
-@fixture
 def general(
     default_institution: str,
 ) -> GeneralConfig:
@@ -92,20 +76,6 @@ def connection(
         hostname=hostname,
         proxy=ProxyConfig(http=proxies["http"], https=proxies["https"]),
         verify_certificate=verify_certificate,
-    )
-
-
-@fixture
-def active_stores(
-    storage_class: StorageTypesEnum,
-    storage_options: Dict[str, str],
-    storage_attributes: Dict[str, str],
-) -> StorageBoxConfig:
-    return StorageBoxConfig(
-        storage_name="Test Active",
-        storage_class=storage_class,
-        options=storage_options,
-        attributes=storage_attributes,
     )
 
 

--- a/tests/fixtures/fixtures_config_from_env.py
+++ b/tests/fixtures/fixtures_config_from_env.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring,redefined-outer-name
 # pylint: disable=missing-module-docstring
 
-from typing import Any, Dict
+from typing import Dict
 
 from pytest import fixture
 
@@ -18,18 +18,8 @@ from src.config.config import (
 
 
 @fixture
-def archive_class() -> StorageTypesEnum:
-    return StorageTypesEnum.S3
-
-
-@fixture
 def storage_class() -> StorageTypesEnum:
     return StorageTypesEnum.FILE_SYSTEM
-
-
-@fixture
-def archive_box_name() -> str:
-    return "Test_archive_box"
 
 
 @fixture
@@ -38,18 +28,8 @@ def storage_box_name() -> str:
 
 
 @fixture
-def archive_box_uri() -> str:
-    return "/api/v1/storagebox/2/"
-
-
-@fixture
 def storage_box_uri() -> str:
     return "/api/v1/storagebox/1/"
-
-
-@fixture
-def archive_box_description() -> str:
-    return "A test archive box"
 
 
 @fixture
@@ -58,25 +38,11 @@ def storage_box_description() -> str:
 
 
 @fixture
-def archive_options() -> Dict[str, str]:
-    return {
-        "S3_Key": "mykey",
-        "S3_password": "mypassword",
-        "bucket": "my_test_bucket",
-    }
-
-
-@fixture
 def storage_options() -> Dict[str, str]:
     return {
         "Location": "/srv/test",
         "target_root_directory": "/srv/mytardis/mytest",
     }
-
-
-@fixture
-def archive_attributes() -> Dict[str, str]:
-    return {"type": "tape"}
 
 
 @fixture
@@ -96,21 +62,6 @@ def active_store(
         storage_class=storage_class,
         options=storage_options,
         attributes=storage_attributes,
-    )
-
-
-@fixture
-def archive_store(
-    archive_box_name: str,
-    archive_class: StorageTypesEnum,
-    archive_options: Dict[str, Any],
-    archive_attributes: Dict[str, Any],
-) -> StorageBoxConfig:
-    return StorageBoxConfig(
-        storage_name=archive_box_name,
-        storage_class=archive_class,
-        options=archive_options,
-        attributes=archive_attributes,
     )
 
 
@@ -155,20 +106,6 @@ def active_stores(
         storage_class=storage_class,
         options=storage_options,
         attributes=storage_attributes,
-    )
-
-
-@fixture
-def archive(
-    archive_class: StorageTypesEnum,
-    archive_options: Dict[str, Any],
-    archive_attributes: Dict[str, Any],
-) -> StorageBoxConfig:
-    return StorageBoxConfig(
-        storage_name="Test Archive",
-        storage_class=archive_class,
-        options=archive_options,
-        attributes=archive_attributes,
     )
 
 

--- a/tests/fixtures/fixtures_constants.py
+++ b/tests/fixtures/fixtures_constants.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-function-docstring,redefined-outer-name,missing-module-docstring
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -10,7 +10,6 @@ from pytz import BaseTzInfo
 from src.blueprints.common_models import GroupACL, Parameter, UserACL
 from src.blueprints.custom_data_types import Username
 from src.blueprints.storage_boxes import StorageTypesEnum
-from src.mytardis_client.common_types import ISODateTime
 from src.mytardis_client.endpoints import URI
 
 
@@ -583,28 +582,8 @@ def institution_name() -> str:
 
 
 @fixture
-def datafile_archive_date() -> ISODateTime:
-    return ISODateTime("2023-12-31T12:00:00+13:00")
-
-
-@fixture
-def datafile_delete_date() -> ISODateTime:
-    return ISODateTime("2025-12-31T12:00:00+13:00")
-
-
-@fixture
-def archive_class() -> StorageTypesEnum:
-    return StorageTypesEnum.S3
-
-
-@fixture
 def storage_class() -> StorageTypesEnum:
     return StorageTypesEnum.FILE_SYSTEM
-
-
-@fixture
-def archive_box_name() -> str:
-    return "Test archive box"
 
 
 @fixture
@@ -613,18 +592,8 @@ def storage_box_name() -> str:
 
 
 @fixture
-def archive_box_uri() -> str:
-    return "/api/v1/storagebox/2/"
-
-
-@fixture
 def storage_box_uri() -> str:
     return "/api/v1/storagebox/1/"
-
-
-@fixture
-def archive_box_description() -> str:
-    return "A test archive box"
 
 
 @fixture
@@ -633,21 +602,8 @@ def storage_box_description() -> str:
 
 
 @fixture
-def archive_options() -> Dict[str, str]:
-    return {
-        "S3_Key": "mykey",
-        "S3_password": "mypassword",
-    }
-
-
-@fixture
 def storage_options() -> Dict[str, str]:
     return {"Location": "/srv/test"}
-
-
-@fixture
-def archive_attributes() -> Dict[str, str]:
-    return {"type": "tape"}
 
 
 @fixture
@@ -661,36 +617,5 @@ def datetime_now(timezone: BaseTzInfo) -> datetime:
 
 
 @fixture
-def autoarchive_offset() -> int:
-    return 547
-
-
-@fixture
-def delete_offset() -> int:
-    return 5470
-
-
-@fixture
-def archive_box_dir() -> Path:
-    return Path("/an/archive/target/")
-
-
-@fixture
 def storage_box_dir() -> Path:
     return Path("/an/active/target/")
-
-
-@fixture
-def archive_date(
-    datetime_now: datetime,
-    autoarchive_offset: int,
-) -> datetime:
-    return datetime_now + timedelta(days=autoarchive_offset)
-
-
-@fixture
-def delete_date(
-    datetime_now: datetime,
-    delete_offset: int,
-) -> datetime:
-    return datetime_now + timedelta(days=delete_offset)

--- a/tests/fixtures/fixtures_dataclasses.py
+++ b/tests/fixtures/fixtures_dataclasses.py
@@ -2,14 +2,12 @@
 # pylint: disable=missing-module-docstring
 
 from datetime import datetime
-from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List
 
 from pytest import fixture
 
 from src.blueprints.common_models import GroupACL, Parameter, ParameterSet, UserACL
-from src.blueprints.custom_data_types import Username
 from src.blueprints.datafile import (
     Datafile,
     DatafileReplica,
@@ -19,7 +17,7 @@ from src.blueprints.datafile import (
 from src.blueprints.dataset import Dataset, RawDataset, RefinedDataset
 from src.blueprints.experiment import Experiment, RawExperiment, RefinedExperiment
 from src.blueprints.project import Project, RawProject, RefinedProject
-from src.mytardis_client.common_types import DataClassification, ISODateTime
+from src.mytardis_client.common_types import DataClassification
 from src.mytardis_client.endpoints import URI
 
 
@@ -46,14 +44,12 @@ def raw_project(  # pylint: disable=too-many-locals,too-many-arguments
     embargo_time_datetime: datetime,
     project_metadata: Dict[str, Any],
     project_url: str,
-    project_data_classification: Enum,
-    autoarchive_offset: int,
-    delete_offset: int,
+    project_data_classification: DataClassification,
 ) -> RawProject:
     return RawProject(
         name=project_name,
         description=project_description,
-        principal_investigator=Username(project_principal_investigator),
+        principal_investigator=project_principal_investigator,
         url=project_url,
         users=split_and_parse_users,
         groups=split_and_parse_groups,
@@ -65,8 +61,6 @@ def raw_project(  # pylint: disable=too-many-locals,too-many-arguments
         identifiers=project_ids,
         metadata=project_metadata,
         data_classification=project_data_classification,
-        autoarchive_offset=autoarchive_offset,
-        delete_offset=delete_offset,
     )
 
 
@@ -205,14 +199,13 @@ def refined_project(  # pylint:disable=too-many-arguments
     end_time_datetime: datetime,
     embargo_time_datetime: datetime,
     project_url: str,
-    project_data_classification: Enum,
+    project_data_classification: DataClassification,
 ) -> RefinedProject:
     return RefinedProject(
         name=project_name,
         description=project_description,
         data_classification=project_data_classification,
-        principal_investigator=Username(project_principal_investigator),
-        dataclassification=project_data_classification,
+        principal_investigator=project_principal_investigator,
         url=project_url,
         users=split_and_parse_users,
         groups=split_and_parse_groups,
@@ -312,7 +305,7 @@ def refined_datafile(
         users=split_and_parse_users,
         groups=split_and_parse_groups,
         dataset=datafile_dataset,
-        parameter_sets=raw_datafile_parameterset,
+        parameter_sets=[raw_datafile_parameterset],
     )
 
 
@@ -332,17 +325,17 @@ def project(
         created_by=refined_project.created_by,
         data_classification=refined_project.data_classification,
         start_time=(
-            ISODateTime(refined_project.start_time.isoformat())
+            refined_project.start_time.isoformat()
             if isinstance(refined_project.start_time, datetime)
             else None
         ),
         end_time=(
-            ISODateTime(refined_project.end_time.isoformat())
+            refined_project.end_time.isoformat()
             if isinstance(refined_project.end_time, datetime)
             else None
         ),
         embargo_until=(
-            ISODateTime(refined_project.embargo_until.isoformat())
+            refined_project.embargo_until.isoformat()
             if isinstance(refined_project.embargo_until, datetime)
             else None
         ),
@@ -429,8 +422,6 @@ def datafile(
     refined_datafile: RefinedDatafile,
     dataset_uri: URI,
     datafile_replica: DatafileReplica,
-    archive_date: datetime,
-    delete_date: datetime,
     archive_replica: DatafileReplica,
 ) -> Datafile:
     return Datafile(
@@ -443,8 +434,6 @@ def datafile(
         groups=refined_datafile.groups,
         dataset=dataset_uri,
         parameter_sets=refined_datafile.parameter_sets,
-        archive_date=ISODateTime(archive_date.isoformat()),
-        delete_date=ISODateTime(delete_date.isoformat()),
         replicas=[
             archive_replica,
             datafile_replica,

--- a/tests/test_smelter.py
+++ b/tests/test_smelter.py
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 logger.propagate = True
 
 
-@pytest.mark.xfail
 @pytest.mark.dependency()
 def test_extract_parameters(
     smelter: Smelter,
@@ -35,7 +34,6 @@ def test_extract_parameters(
     )
 
 
-@pytest.mark.xfail
 def test_extract_parameters_metadata_none(
     smelter: Smelter,
     raw_project: RawProject,
@@ -46,7 +44,6 @@ def test_extract_parameters_metadata_none(
     assert smelter.extract_parameters(project_schema, raw_project) is None
 
 
-@pytest.mark.xfail
 def test_extract_parameters_object_schema_none(
     smelter: Smelter,
     raw_project: RawProject,
@@ -60,7 +57,6 @@ def test_extract_parameters_object_schema_none(
     )
 
 
-@pytest.mark.xfail
 def test_smelt_project(
     smelter: Smelter,
     raw_project: RawProject,
@@ -73,7 +69,6 @@ def test_smelt_project(
     )
 
 
-@pytest.mark.xfail
 def test_smelt_project_projects_disabled(
     caplog: pytest.LogCaptureFixture,
     smelter: Smelter,
@@ -89,7 +84,6 @@ def test_smelt_project_projects_disabled(
     assert error_str in caplog.text
 
 
-@pytest.mark.xfail
 def test_smelt_project_object_use_default_schema(
     smelter: Smelter,
     raw_project: RawProject,
@@ -107,7 +101,6 @@ def test_smelt_project_object_use_default_schema(
     assert result == (refined_project, raw_project_parameterset)
 
 
-@pytest.mark.xfail
 def test_smelt_project_use_default_institution(
     smelter: Smelter,
     raw_project: RawProject,
@@ -127,7 +120,6 @@ def test_smelt_project_use_default_institution(
     )
 
 
-@pytest.mark.xfail
 def test_smelt_project_no_institution(
     caplog: Any,
     smelter: Smelter,
@@ -142,7 +134,6 @@ def test_smelt_project_no_institution(
     assert error_str in caplog.text
 
 
-@pytest.mark.xfail
 def test_smelt_project_no_schema(
     caplog: Any,
     smelter: Smelter,
@@ -157,7 +148,6 @@ def test_smelt_project_no_schema(
     assert error_str in caplog.text
 
 
-@pytest.mark.xfail
 def test_smelt_experiment(
     smelter: Smelter,
     raw_experiment: RawExperiment,
@@ -170,7 +160,6 @@ def test_smelt_experiment(
     )
 
 
-@pytest.mark.xfail
 def test_smelt_experiment_projects_enabled(
     caplog: pytest.LogCaptureFixture,
     smelter: Smelter,
@@ -186,7 +175,6 @@ def test_smelt_experiment_projects_enabled(
     assert error_str in caplog.text
 
 
-@pytest.mark.xfail
 def test_smelt_experiment_object_use_default_schema(
     smelter: Smelter,
     raw_experiment: RawExperiment,
@@ -204,7 +192,6 @@ def test_smelt_experiment_object_use_default_schema(
     assert result == (refined_experiment, raw_experiment_parameterset)
 
 
-@pytest.mark.xfail
 def test_smelt_experiment_no_schema(
     caplog: pytest.LogCaptureFixture,
     smelter: Smelter,
@@ -219,7 +206,6 @@ def test_smelt_experiment_no_schema(
     assert error_str in caplog.text
 
 
-@pytest.mark.xfail
 def test_smelt_experiment_use_default_institution(
     smelter: Smelter,
     raw_experiment: RawExperiment,
@@ -236,7 +222,6 @@ def test_smelt_experiment_use_default_institution(
     assert result == (refined_experiment, raw_experiment_parameterset)
 
 
-@pytest.mark.xfail
 def test_smelt_experiment_no_institution(
     caplog: Any,
     smelter: Smelter,
@@ -251,7 +236,6 @@ def test_smelt_experiment_no_institution(
     assert error_str in caplog.text
 
 
-@pytest.mark.xfail
 def test_smelt_dataset(
     smelter: Smelter,
     raw_dataset: RawDataset,
@@ -264,7 +248,6 @@ def test_smelt_dataset(
     )
 
 
-@pytest.mark.xfail
 def test_smelt_dataset_use_default_schema(
     smelter: Smelter,
     raw_dataset: RawDataset,
@@ -282,7 +265,6 @@ def test_smelt_dataset_use_default_schema(
     assert result == (refined_dataset, raw_dataset_parameterset)
 
 
-@pytest.mark.xfail
 def test_smelt_dataset_no_schema(
     caplog: pytest.LogCaptureFixture,
     smelter: Smelter,
@@ -297,7 +279,6 @@ def test_smelt_dataset_no_schema(
     assert error_str in caplog.text
 
 
-@pytest.mark.xfail
 def test_smelt_datafile(
     smelter: Smelter,
     raw_datafile: RawDatafile,
@@ -306,7 +287,6 @@ def test_smelt_datafile(
     assert smelter.smelt_datafile(raw_datafile) == refined_datafile
 
 
-@pytest.mark.xfail
 def test_smelt_datafile_use_default_schema(
     smelter: Smelter,
     raw_datafile: RawDatafile,
@@ -318,11 +298,12 @@ def test_smelt_datafile_use_default_schema(
 
     assert result is not None
     if result.parameter_sets:
-        assert result.parameter_sets.parameter_schema == smelter.default_schema.datafile
+        assert (
+            result.parameter_sets[0].parameter_schema == smelter.default_schema.datafile
+        )
     assert result == refined_datafile
 
 
-@pytest.mark.xfail
 def test_smelt_datafile_no_schema(
     caplog: pytest.LogCaptureFixture,
     smelter: Smelter,


### PR DESCRIPTION
- Delete various unused test fixtures (mostly related to deprecated archive-related features)
- Fix a few fixtures (remove deprecated constructor parameters etc.)
- Reinstate the smelter tests (remove `@xfail`) after fixing the corresponding broken fixtures