### PR TITLE
Remove singleton status from Overseer

### DIFF
--- a/src/overseers/overseer.py
+++ b/src/overseers/overseer.py
@@ -12,7 +12,6 @@ from src.mytardis_client.endpoints import URI, MyTardisEndpoint
 from src.mytardis_client.mt_rest import MyTardisRESTFactory
 from src.mytardis_client.objects import MyTardisObject, get_type_info
 from src.mytardis_client.response_data import MyTardisIntrospection, MyTardisResource
-from src.utils.types.singleton import Singleton
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +64,7 @@ def extract_values_for_matching(
     return match_keys
 
 
-class Overseer(metaclass=Singleton):
+class Overseer:
     """The Overseer class inspects MyTardis
 
     Overseer classes inspect the MyTardis database to ensure

--- a/tests/ignored/ignoredtest_ingestion_factory.py
+++ b/tests/ignored/ignoredtest_ingestion_factory.py
@@ -156,7 +156,6 @@ def test_ingest_project(
 
     assert ingestion_factory.ingest_projects([raw_project]) == expected_result
     assert warning in caplog.text
-    Overseer.clear()
     Smelter.clear()
     Crucible.clear()
     MyTardisRESTFactory.clear()
@@ -207,7 +206,6 @@ def test_ingest_experiment(
 
     assert ingestion_factory.ingest_experiments([raw_experiment]) == expected_result
     assert warning in caplog.text
-    Overseer.clear()
     Smelter.clear()
     Crucible.clear()
     MyTardisRESTFactory.clear()
@@ -258,7 +256,6 @@ def test_ingest_dataset(
 
     assert ingestion_factory.ingest_datasets([raw_dataset]) == expected_result
     assert warning in caplog.text
-    Overseer.clear()
     Smelter.clear()
     Crucible.clear()
     MyTardisRESTFactory.clear()
@@ -309,7 +306,6 @@ def test_ingest_datafile(
 
     assert ingestion_factory.ingest_datafiles([raw_datafile]) == expected_result
     assert warning in caplog.text
-    Overseer.clear()
     Smelter.clear()
     Crucible.clear()
     MyTardisRESTFactory.clear()

--- a/tests/test_overseers.py
+++ b/tests/test_overseers.py
@@ -90,8 +90,6 @@ def test_get_matches_from_mytardis(
         == expected_projects
     )
 
-    Overseer.clear()
-
 
 @responses.activate
 def test_get_objects_http_error(
@@ -125,8 +123,6 @@ def test_get_objects_http_error(
     with pytest.raises(RuntimeError):
         overseer.get_matching_objects(object_type, {"name": search_string})
 
-    Overseer.clear()
-
 
 @mock.patch("src.mytardis_client.mt_rest.MyTardisRESTFactory.request")
 def test_get_objects_general_error(
@@ -145,8 +141,6 @@ def test_get_objects_general_error(
     with pytest.raises(RuntimeError):
         _ = overseer.get_matching_objects(object_type, {"name": search_string})
         assert error_str in caplog.text
-
-    Overseer.clear()
 
 
 @responses.activate
@@ -183,8 +177,6 @@ def test_get_objects_no_objects(
 
     assert overseer.get_matching_objects(object_type, {"name": search_string}) == []
 
-    Overseer.clear()
-
 
 @responses.activate
 def test_get_uris(
@@ -211,8 +203,6 @@ def test_get_uris(
         MyTardisObject.PROJECT,
         search_string,
     ) == [URI("/api/v1/project/1/")]
-
-    Overseer.clear()
 
 
 @responses.activate
@@ -252,7 +242,6 @@ def test_get_uris_no_objects(
         )
         == []
     )
-    Overseer.clear()
 
 
 @responses.activate
@@ -296,8 +285,6 @@ def test_get_uris_malformed_return_dict(
             search_string,
         )
 
-    Overseer.clear()
-
 
 @responses.activate
 def test_get_uris_ensure_http_errors_caught_by_get_objects(
@@ -333,8 +320,6 @@ def test_get_uris_ensure_http_errors_caught_by_get_objects(
             search_string,
         )
 
-    Overseer.clear()
-
 
 @mock.patch("src.mytardis_client.mt_rest.MyTardisRESTFactory.request")
 def test_get_uris_general_error(
@@ -349,7 +334,6 @@ def test_get_uris_general_error(
             object_type,
             search_string,
         )
-    Overseer.clear()
 
 
 @responses.activate
@@ -373,7 +357,6 @@ def test_get_mytardis_setup(
     )
 
     assert overseer_plain.mytardis_setup == mytardis_introspection
-    Overseer.clear()
 
 
 @responses.activate
@@ -393,7 +376,6 @@ def test_get_mytardis_setup_http_error(
     with pytest.raises(HTTPError):
         _ = overseer.fetch_mytardis_setup()
         assert error_str in caplog.text
-    Overseer.clear()
 
 
 @mock.patch("src.overseers.overseer.Overseer.fetch_mytardis_setup")
@@ -407,7 +389,6 @@ def test_get_mytardis_setup_general_error(
     with pytest.raises(IOError):
         _ = overseer.fetch_mytardis_setup()
         assert error_str in caplog.text
-    Overseer.clear()
 
 
 @responses.activate
@@ -428,8 +409,6 @@ def test_get_mytardis_setup_no_objects(
 
     with pytest.raises(ValueError):
         _ = overseer.fetch_mytardis_setup()
-
-    Overseer.clear()
 
 
 @responses.activate
@@ -452,5 +431,3 @@ def test_get_mytardis_setup_too_many_objects(
 
     with pytest.raises(ValueError):
         _ = overseer.fetch_mytardis_setup()
-
-    Overseer.clear()


### PR DESCRIPTION
Convert the Overseer class to be no longer a singleton, as it doesn't appear to be needed, and sometimes confounds the pylance type-checking.