### PR TITLE
Increase timeouts and improve retry-handling for requests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -262,17 +262,6 @@ files = [
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 
 [[package]]
-name = "backoff"
-version = "2.2.1"
-description = "Function decoration for backoff and retry"
-optional = false
-python-versions = ">=3.7,<4.0"
-files = [
-    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
-    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
-]
-
-[[package]]
 name = "bandit"
 version = "1.7.9"
 description = "Security oriented static analyser for python code."
@@ -3777,4 +3766,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "55ef47539d6d9ea3d2afbf794f05f05ca88df1ea1bee95dd81278be4ce256184"
+content-hash = "c7fc4536719485e4d31fb389508f326ed9eedd89fef536e04f7687b805a1e170"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ pydantic-settings = "^2.3.4"
 validators = "^0.33.0"
 typer = "^0.12.0"
 rocrate = "^0.10.0"
+tenacity = "^9.0.0"
 typing-extensions = "^4.12.2"
 types-pyyaml = "^6.0.12.20240808"
 typeguard = "^4.3.0"
-tenacity = "^9.0.0"
 
 [tool.poetry.group.dev.dependencies]
 wily = "^1.25.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ packages = [{include = "src"}]
 [tool.poetry.dependencies]
 python = ">=3.10,<3.12"
 requests = "^2.31.0"
-backoff = "^2.2.1"
 PyYAML = "^6.0"
 pydantic = "^2.8.2"
 pytz = "^2024.1"
@@ -21,6 +20,7 @@ rocrate = "^0.10.0"
 typing-extensions = "^4.12.2"
 types-pyyaml = "^6.0.12.20240808"
 typeguard = "^4.3.0"
+tenacity = "^9.0.0"
 
 [tool.poetry.group.dev.dependencies]
 wily = "^1.25.0"

--- a/src/mytardis_client/mt_rest.py
+++ b/src/mytardis_client/mt_rest.py
@@ -12,8 +12,7 @@ from urllib.parse import urljoin
 
 import requests
 from pydantic import BaseModel, ValidationError
-from requests import Response
-from requests.exceptions import ReadTimeout, RequestException
+from requests import ConnectTimeout, ReadTimeout, RequestException, Response
 from tenacity import (
     before_sleep_log,
     retry,
@@ -201,7 +200,9 @@ class MyTardisRESTFactory:
         return urljoin(self._url_base, path)
 
     @retry(
-        retry=retry_if_exception_type((BadGateWayException, ReadTimeout)),
+        retry=retry_if_exception_type(
+            (BadGateWayException, ConnectTimeout, ReadTimeout)
+        ),
         wait=wait_exponential(),
         stop=stop_after_attempt(8),
         before_sleep=before_sleep_log(logger, logging.INFO),


### PR DESCRIPTION
Changes to the timeout and retry behaviour for requests in the MyTardis client:

- Increase the default request timeout from 5s to 30s (to account for occasional long delays which have been causing long-running ingestions to crash)
- Make timeouts trigger a retry of the request (previously we were just doing this for 502 returns)
- Log when retries occur
- Override the retry delay in the tests, so we're only testing for the retry delay itself, in order to reduce the test run duration. This has reduced the time taken to run the full set of tests from 1-2 minutes to 3 seconds.

As part of this, switch from the `backoff` package to `tenacity` for the retry logic. The latter seems more actively supported, and is already an indirect dependency.