### PR TITLE
Make the logging verbosity level configurable via command-line arguments

### DIFF
--- a/src/cli/cmd_clean.py
+++ b/src/cli/cmd_clean.py
@@ -121,6 +121,7 @@ def _delete_datafiles(df_paths: list[Path]) -> None:
             )
 
 
+# pylint: disable=too-many-locals
 def clean(
     source_data_path: SourceDataPathArg,
     profile_name: ProfileNameOption,

--- a/src/cli/cmd_clean.py
+++ b/src/cli/cmd_clean.py
@@ -11,6 +11,7 @@ import typer
 from src.blueprints.datafile import RawDatafile
 from src.cli.common import (
     LogFileOption,
+    LogLevelOption,
     ProfileNameOption,
     ProfileVersionOption,
     SourceDataPathArg,
@@ -144,9 +145,10 @@ def clean(
         ),
     ] = None,
     log_file: LogFileOption = Path("clean.log"),
+    log_level: LogLevelOption = "INFO",
 ) -> None:
     """Delete datafiles in source data source after ingestion is complete."""
-    log_utils.init_logging(file_name=str(log_file))
+    log_utils.init_logging(file_name=str(log_file), level=log_level)
 
     logger.info("Extracting list of datafiles using %s profile", profile_name)
     profile = load_profile(profile_name, profile_version)

--- a/src/cli/cmd_ingest.py
+++ b/src/cli/cmd_ingest.py
@@ -8,6 +8,7 @@ import typer
 
 from src.cli.common import (
     LogFileOption,
+    LogLevelOption,
     ProfileNameOption,
     ProfileVersionOption,
     SourceDataPathArg,
@@ -35,6 +36,7 @@ def extract(
     profile_name: ProfileNameOption,
     profile_version: ProfileVersionOption = None,
     log_file: LogFileOption = Path("extraction.log"),
+    log_level: LogLevelOption = "INFO",
 ) -> None:
     """
     Extract metadata from a directory tree, parse it into a MyTardis PEDD structure,
@@ -43,7 +45,7 @@ def extract(
     The 'upload' command be used to ingest this extracted data into MyTardis.
     """
 
-    log_utils.init_logging(file_name=str(log_file), level=logging.DEBUG)
+    log_utils.init_logging(file_name=str(log_file), level=log_level)
     timer = Timer(start=True)
 
     profile = load_profile(profile_name, profile_version)
@@ -73,11 +75,12 @@ def upload(
     ],
     storage: StorageBoxOption = None,
     log_file: LogFileOption = Path("upload.log"),
+    log_level: LogLevelOption = "INFO",
 ) -> None:
     """
     Submit the extracted metadata to MyTardis, and transfer the data to the storage directory.
     """
-    log_utils.init_logging(file_name=str(log_file), level=logging.DEBUG)
+    log_utils.init_logging(file_name=str(log_file), level=log_level)
     config = get_config(storage)
     if DirectoryNode(manifest_dir).empty():
         raise ValueError(
@@ -106,11 +109,12 @@ def ingest(
     storage: StorageBoxOption = None,
     profile_version: ProfileVersionOption = None,
     log_file: LogFileOption = Path("ingestion.log"),
+    log_level: LogLevelOption = "INFO",
 ) -> None:
     """
     Run the full ingestion process, from extracting metadata to ingesting it into MyTardis.
     """
-    log_utils.init_logging(file_name=str(log_file), level=logging.DEBUG)
+    log_utils.init_logging(file_name=str(log_file), level=log_level)
     config = get_config(storage)
     timer = Timer(start=True)
 

--- a/src/cli/common.py
+++ b/src/cli/common.py
@@ -43,6 +43,24 @@ LogFileOption: TypeAlias = Annotated[
     typer.Option(help="Path to be used for the log file"),
 ]
 
+LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+
+
+def validate_log_level(value: str) -> str:
+    """Validate the log level passed in as a string."""
+    if value.upper() not in LOG_LEVELS:
+        raise typer.BadParameter(message=f"'{value}'. Valid values are {LOG_LEVELS}.")
+    return value.upper()
+
+
+LogLevelOption: TypeAlias = Annotated[
+    str,
+    typer.Option(
+        help=f"Logging verbosity level. Options: {LOG_LEVELS}",
+        callback=validate_log_level,
+    ),
+]
+
 StorageBoxOption: TypeAlias = Annotated[
     Optional[tuple[str, Path]],
     typer.Option(

--- a/src/utils/log_utils.py
+++ b/src/utils/log_utils.py
@@ -7,7 +7,9 @@ import sys
 from typing import Optional
 
 
-def init_logging(file_name: Optional[str] = None, level: int = logging.DEBUG) -> None:
+def init_logging(
+    file_name: Optional[str] = None, level: int | str = logging.DEBUG
+) -> None:
     """
     Configure a basic default logging setup. Logs to the console, and optionally
     to a file, if a filename is passed.


### PR DESCRIPTION
Add an optional command-line argument "--log-level" in the ingestion CLI, so that the user can change the logging verbosity. Prior to this change, the level was hard-coded to DEBUG.