### PR TITLE
Ensure transfer resumes if metadata already ingested

### DIFF
--- a/src/ingestion_factory/factory.py
+++ b/src/ingestion_factory/factory.py
@@ -205,7 +205,7 @@ class IngestionFactory:
     ) -> IngestionResult:
         """Ingest a set of datafiles into MyTardis."""
         result = IngestionResult()
-        datafiles: list[Datafile] = []
+        datafiles_to_transfer: list[Datafile] = []
 
         datafiles_prefetched: dict[URI, bool] = {}
 
@@ -244,11 +244,12 @@ class IngestionFactory:
                     datafile.filepath,
                     matching_datafiles[0].resource_uri,
                 )
+                datafiles_to_transfer.append(datafile)
                 result.skipped.append((datafile.display_name, None))
                 continue
 
             self.forge.forge_datafile(datafile)
-            datafiles.append(datafile)
+            datafiles_to_transfer.append(datafile)
             result.success.append((datafile.display_name, None))
 
         logger.info(
@@ -266,7 +267,7 @@ class IngestionFactory:
         # Create a file transfer with the conveyor
         logger.info("Starting transfer of datafiles.")
         try:
-            self.conveyor.transfer(source_data_root, datafiles)
+            self.conveyor.transfer(source_data_root, datafiles_to_transfer)
             logger.info("Finished transferring datafiles.")
         except FailedTransferException:
             logger.error(

--- a/src/mytardis_client/response_data.py
+++ b/src/mytardis_client/response_data.py
@@ -299,7 +299,7 @@ class IngestedDataset(MyTardisObjectData):
     classification: DataClassification
     created_time: ISODateTime
     description: str
-    directory: Path
+    directory: Optional[Path]
     experiments: list[URI]
     identifiers: list[str]
     immutable: bool


### PR DESCRIPTION
This small PR fixes an issue where interrupted datafile transfers will not be resumed at the next pipeline run. This is because the script will not attempt to transfer datafiles with ingested metadata. The fix adds to this logic.
It also fixes a bug in the type annotation for Dataset from MyTardis. 