### PR TITLE
Fix: invalidation of response cache

### DIFF
--- a/src/mytardis_client/mt_rest.py
+++ b/src/mytardis_client/mt_rest.py
@@ -152,7 +152,13 @@ def endpoint_is_not(
 
 def has_objects(response: Response) -> bool:
     """Check whether a response contains any objects or not"""
-    if objects := response.json().get("objects"):
+
+    try:
+        response_json = response.json()
+    except requests.exceptions.JSONDecodeError:
+        return False
+
+    if objects := response_json.get("objects"):
         return len(objects) > 0
 
     return False

--- a/src/utils/types/type_helpers.py
+++ b/src/utils/types/type_helpers.py
@@ -22,8 +22,8 @@ Predicate: TypeAlias = Callable[[T], bool]
 def all_true(predicates: list[Predicate[T]]) -> Predicate[T]:
     """Compose a list of predicates into a single predicate.
 
-    The composed predicate will return True if any of the predicates in the list
-    return True for the object being tested.
+    The composed predicate will return True if all of the predicates in the list
+    return True for the given argument.
     """
 
     def all_preds_true(obj: T) -> bool:

--- a/src/utils/types/type_helpers.py
+++ b/src/utils/types/type_helpers.py
@@ -1,6 +1,6 @@
 """Helpers for working with types and type-checking."""
 
-from typing import Any, Protocol, TypeGuard, TypeVar
+from typing import Any, Callable, Protocol, TypeAlias, TypeGuard, TypeVar
 
 T = TypeVar("T")
 
@@ -14,6 +14,22 @@ def is_list_of(obj: Any, query_type: type[T]) -> TypeGuard[list[T]]:
     """Check if an object is a list with elements of a certain type."""
 
     return isinstance(obj, list) and all(isinstance(entry, query_type) for entry in obj)
+
+
+Predicate: TypeAlias = Callable[[T], bool]
+
+
+def all_true(predicates: list[Predicate[T]]) -> Predicate[T]:
+    """Compose a list of predicates into a single predicate.
+
+    The composed predicate will return True if any of the predicates in the list
+    return True for the object being tested.
+    """
+
+    def all_preds_true(obj: T) -> bool:
+        return all(predicate(obj) for predicate in predicates)
+
+    return all_preds_true
 
 
 class Stringable(Protocol):

--- a/tests/test_mytardis_client_rest_factory.py
+++ b/tests/test_mytardis_client_rest_factory.py
@@ -22,7 +22,7 @@ from src.mytardis_client.mt_rest import (
     GetRequestMetaParams,
     GetResponseMeta,
     MyTardisRESTFactory,
-    make_endpoint_filter,
+    endpoint_is_not,
     sanitize_params,
 )
 from src.mytardis_client.response_data import IngestedDatafile
@@ -333,4 +333,4 @@ def test_make_endpoint_filter(
     response = MagicMock()
     response.url = url
 
-    assert make_endpoint_filter(endpoints)(response) == expected_output
+    assert endpoint_is_not(endpoints)(response) == expected_output


### PR DESCRIPTION
Following the introduction of caching of responses from MyTardis, we have run into problems related to invalidation of the cache during ingestion.

For example, when ingesting a new project, we first send a request to see if there's already a matching project. The response contains no matching objects, and we cache the empty list. We then submit (POST) the project metadata to MyTardis. Then we try to submit an experiment under the new project. We fail to retrieve the project URI needed to ingest the experiment, because we hit the cache which contains an empty list.

The fix here is to avoid caching responses from MyTardis if they contain no objects.