### PR TITLE
IDS-915: Remove unnecessary test data factory functions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,8 @@ institution_uri = const.institution_uri
 instrument_uri = const.instrument_uri
 user_uri = const.user_uri
 institution_address = const.institution_address
-institution_ids = const.institution_ids
+institution_identifiers = const.institution_identifiers
+institution_id = const.institution_id
 institution_country = const.institution_country
 institution_name = const.institution_name
 storage_class = const.storage_class
@@ -158,12 +159,9 @@ project = dcls.project
 experiment = dcls.experiment
 dataset = dcls.dataset
 datafile = dcls.datafile
+ingested_datafile = dcls.ingested_datafile
+institution = dcls.institution
 datafile_replica = dcls.datafile_replica
-make_project = dcls.make_project
-make_refined_project = dcls.make_refined_project
-make_datafile = dcls.make_datafile
-make_ingested_datafile = dcls.make_ingested_datafile
-make_institution = dcls.make_institution
 
 # =========================================
 #

--- a/tests/fixtures/fixtures_constants.py
+++ b/tests/fixtures/fixtures_constants.py
@@ -547,11 +547,6 @@ def datafile_uri() -> URI:
 
 
 @fixture
-def institution_uri() -> URI:
-    return URI("/api/v1/institution/1/")
-
-
-@fixture
 def instrument_uri() -> URI:
     return URI("/api/v1/instrument/1/")
 
@@ -562,12 +557,22 @@ def user_uri() -> URI:
 
 
 @fixture
+def institution_id() -> int:
+    return 1
+
+
+@fixture
+def institution_uri(institution_id: int) -> URI:
+    return URI(f"/api/v1/institution/{institution_id}/")
+
+
+@fixture
 def institution_address() -> str:
     return "23 Symonds Street"
 
 
 @fixture
-def institution_ids() -> List[str]:
+def institution_identifiers() -> List[str]:
     return ["UoA123", "UoA", "Uni"]
 
 

--- a/tests/fixtures/fixtures_constants.py
+++ b/tests/fixtures/fixtures_constants.py
@@ -8,7 +8,6 @@ from pytest import fixture
 from pytz import BaseTzInfo
 
 from src.blueprints.common_models import GroupACL, Parameter, UserACL
-from src.blueprints.custom_data_types import Username
 from src.blueprints.storage_boxes import StorageTypesEnum
 from src.mytardis_client.endpoints import URI
 
@@ -452,7 +451,7 @@ def split_and_parse_users(
 ) -> List[UserACL]:
     return_list = [
         UserACL(
-            user=Username(admin_user),
+            user=admin_user,
             is_owner=True,
             can_download=True,
             see_sensitive=True,
@@ -471,7 +470,7 @@ def split_and_parse_users(
             sensitive = True
         return_list.append(
             UserACL(
-                user=Username(user),
+                user=user,
                 is_owner=False,
                 can_download=download,
                 see_sensitive=sensitive,

--- a/tests/fixtures/fixtures_dataclasses.py
+++ b/tests/fixtures/fixtures_dataclasses.py
@@ -3,9 +3,8 @@
 
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Protocol, TypeVar
+from typing import Any, Dict, List
 
-from pydantic import BaseModel
 from pytest import fixture
 
 from src.blueprints.common_models import GroupACL, Parameter, ParameterSet, UserACL
@@ -446,120 +445,39 @@ def datafile(
     )
 
 
-T_co = TypeVar("T_co", bound=BaseModel, covariant=True)
-
-
-class TestModelFactory(Protocol[T_co]):
-    """Protocol for a factory function that creates pydantic models to be used in tests.
-
-    Used in place of Callable[] as it is difficult to declare a Callable taking **kwargs
-    """
-
-    def __call__(self, **kwargs: Any) -> T_co: ...
-
-
-_DEFAULT_DATACLASS_ARGS: dict[type, dict[str, Any]] = {
-    Project: {
-        "name": "Test Project",
-        "description": "Test project description",
-        "principal_investigator": "test001",
-        "institution": ["/api/v1/institution/1/"],
-    },
-    RefinedProject: {
-        "name": "Test Project",
-        "description": "Test project description",
-        "principal_investigator": "test001",
-        "institution": ["test-institution-1"],
-    },
-    Datafile: {
-        "filename": "test_file.txt",
-        "directory": Path("path/to/datafile"),
-        "md5sum": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-        "mimetype": "text/plain",
-        "size": 1024,
-        "users": None,
-        "groups": None,
-        "data_status": None,
-        "replicas": [],
-        "parameter_sets": None,
-        "dataset": URI("/api/v1/dataset/1/"),
-    },
-    IngestedDatafile: {
-        "resource_uri": URI("/api/v1/dataset_file/1/"),
-        "id": 1,
-        "dataset": URI("/api/v1/dataset/1/"),
-        "deleted": False,
-        "directory": Path("path/to/df_1"),
-        "filename": "df_1.txt",
-        "md5sum": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
-        "mimetype": "text/plain",
-        "parameter_sets": [],
-        "public_access": False,
-        "replicas": [],
-        "size": 1024,
-        "version": 1,
-        "created_time": None,
-        "deleted_time": None,
-        "modification_time": None,
-        "identifiers": ["dataset-id-1"],
-    },
-    Institution: {
-        "name": "Test Institution",
-        "identifiers": ["test-institution-1"],
-        "id": 1,
-        "resource_uri": URI("/api/v1/institution/1/"),
-    },
-}
-
-
-def make_dataclass_factory(dc_type: type[T_co]) -> TestModelFactory[T_co]:
-    """Factory function for creating factories for specific dataclasses.
-
-    Returns a function that creates instances of the specified dataclass with default
-    argument values. These values can be overridden by passing keyword arguments to the
-    factory function. This allows testers to easily create instances of dataclasses,
-    while only specifying the values that are relevant to the test.
-
-    Args:
-        dc_type: The dataclass type for which to create a factory function.
-
-    Returns:
-        A factory function that creates instances of the specified dataclass 'dc_type'.
-    """
-
-    default_args = _DEFAULT_DATACLASS_ARGS[dc_type]
-
-    def _make_dataclass(**kwargs: Any) -> T_co:
-        """Create an instance of the dataclass with the specified keyword arguments and
-        and default values (kwargs are given priority over default values).
-        """
-
-        result = {**default_args, **kwargs}
-        return dc_type.model_validate(result)
-
-    return _make_dataclass
+@fixture
+def institution(
+    institution_name: str,
+    institution_identifiers: list[str],
+    institution_id: int,
+    institution_uri: URI,
+) -> Institution:
+    return Institution(
+        name=institution_name,
+        identifiers=institution_identifiers,
+        id=institution_id,
+        resource_uri=institution_uri,
+    )
 
 
 @fixture
-def make_project() -> TestModelFactory[Project]:
-    return make_dataclass_factory(Project)
-
-
-@fixture
-def make_refined_project() -> TestModelFactory[RefinedProject]:
-    return make_dataclass_factory(RefinedProject)
-
-
-@fixture
-def make_datafile() -> TestModelFactory[Datafile]:
-    return make_dataclass_factory(Datafile)
-
-
-@fixture
-def make_ingested_datafile() -> TestModelFactory[IngestedDatafile]:
-    return make_dataclass_factory(IngestedDatafile)
-
-
-@fixture
-def make_institution() -> TestModelFactory[Institution]:
-    return make_dataclass_factory(Institution)
+def ingested_datafile() -> IngestedDatafile:
+    return IngestedDatafile(
+        resource_uri=URI("/api/v1/dataset_file/1/"),
+        id=1,
+        dataset=URI("/api/v1/dataset/1/"),
+        deleted=False,
+        directory=Path("path/to/df_1"),
+        filename="df_1.txt",
+        md5sum="FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+        mimetype="text/plain",
+        parameter_sets=[],
+        public_access=False,
+        replicas=[],
+        size=1024,
+        version=1,
+        created_time=None,
+        deleted_time=None,
+        modification_time=None,
+        identifiers=["dataset-id-1"],
+    )

--- a/tests/fixtures/fixtures_responses.py
+++ b/tests/fixtures/fixtures_responses.py
@@ -394,7 +394,7 @@ def introspection_response() -> dict[str, Any]:
 def institution_response_dict(
     institution_uri: URI,
     institution_address: str,
-    institution_ids: List[str],
+    institution_identifiers: List[str],
     institution_country: str,
     institution_name: str,
 ) -> Dict[str, Any]:
@@ -411,7 +411,7 @@ def institution_response_dict(
                 "address": institution_address,
                 "aliases": 1,
                 "country": institution_country,
-                "identifiers": institution_ids,
+                "identifiers": institution_identifiers,
                 "name": institution_name,
                 "resource_uri": institution_uri,
             }


### PR DESCRIPTION
Remove some test fixture factory functions used to generate dataclasses for tests, as the implementation has proven difficult to understand at first glance, is not type-checker-friendly, and does not appear to save much effort over copying-and-overriding-fields from the plain fixture objects.